### PR TITLE
[Feature] Add profile mode

### DIFF
--- a/examples/found/package.json
+++ b/examples/found/package.json
@@ -6,7 +6,8 @@
     "start": "webpack-dev-server --mode=development",
     "build": "webpack --mode=production",
     "analyze": "webpack --mode=production --analyze",
-    "pkgcheck": "webpack --check=nobuild"
+    "pkgcheck": "webpack --check=nobuild",
+    "profile": "webpack --mode=production --profile"
   },
   "devDependencies": {
     "@anansi/babel-preset": "^0.18.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,6 +7,7 @@
     "build": "webpack --mode=production",
     "build:server": "webpack --mode=production --target=node",
     "analyze": "webpack --mode=production --analyze",
+    "profile": "webpack --mode=production --profile",
     "pkgcheck": "webpack --check=nobuild",
     "type-check": "tsc --noEmit",
     "storybook": "start-storybook -p 6006",

--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -56,6 +56,9 @@ If set will run package checks to check for duplicates or ciruclar dependencies.
 Examples:
 `webpack --mode=production --check` or `webpack --check=nobuild`
 
+### profile
+If set, will enable [React DevTools Profiler](https://reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html). This feature is only available in production mode since it is enabled in development by default.
+
 ## Options
 
 Pass these to makeConfig.

--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -107,6 +107,8 @@ export default function makeProdConfig(
           comments: false,
           ascii_only: true,
         },
+        keep_classnames: !!argv?.profile,
+        keep_fnames: !!argv?.profile,
       },
       sourceMap: true,
       extractComments: true,
@@ -153,5 +155,12 @@ export default function makeProdConfig(
   );
   config.module.rules = [...config.module.rules, ...styleRules];
 
+  if (argv?.profile) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'react-dom$': 'react-dom/profiling',
+      'scheduler/tracing': 'scheduler/tracing-profiling'
+    }
+  }
   return config;
 }


### PR DESCRIPTION
Adds profile mode to enable React profiler in production. Tested by running `yarn link` and using production build of another project.