### PR TITLE
[webpack][breaking] CLI mode should override ENV variables set

### DIFF
--- a/packages/webpack-config-anansi/src/index.js
+++ b/packages/webpack-config-anansi/src/index.js
@@ -13,9 +13,7 @@ export makeStorybookConfigGenerator from './storybook';
 
 export function makeConfig(options) {
   return (env, argv) => {
-    if (!process.env.NODE_ENV) {
-      process.env.NODE_ENV = argv?.mode;
-    }
+    process.env.NODE_ENV = argv?.mode;
     // eslint-disable-next-line no-param-reassign
     options = {
       rootPath: ROOT_PATH,


### PR DESCRIPTION
`--mode=production` should override NODE_ENV=test for instance.

This is logical because running a command in CLI is more specific as it is a case-by-case basis; whereas env persists between commands. More specific should always override less specific.