### PR TITLE
feat: Use preset-modules when target is set to esmodules: true

### DIFF
--- a/packages/babel-preset-anansi/README.md
+++ b/packages/babel-preset-anansi/README.md
@@ -53,7 +53,12 @@ Will run to target node instead of browsers. Specify a [valid node string](https
 
 ### targets : ?object = undefined
 
-*NOT recommended.* Can be used to override babel-preset-env targets for non-testing environment.
+Set to `{ "esmodules": true }` to produce extra optimal bundles for modern browsers that support
+ES modules. This will make use of `@babel/preset-modules` instead of `@babel/preset-env`, whose transforms
+are more compact and efficient.
+
+*NOT recommended for non-`{ "esmodules": true }`.* Can be used to override `@babel/preset-env` targets
+for non-testing environment.
 Use a [browserslist config](https://github.com/browserslist/browserslist#packagejson) instead.
 
 Feel free to use the [anansi browserlist config](/packages/browserslist-config-anansi).

--- a/packages/babel-preset-anansi/index.js
+++ b/packages/babel-preset-anansi/index.js
@@ -148,18 +148,26 @@ function buildPreset(api, options = {}) {
       preset.plugins.push(require('babel-plugin-dynamic-import-node'));
     }
   } else {
-    preset.presets.unshift([
-      require('@babel/preset-env').default,
-      {
-        targets: options.targets,
-        modules,
-        useBuiltIns: options.useBuiltIns,
-        corejs: options.corejs,
-        loose: options.loose,
-        // Exclude transforms that make all code slower
-        exclude: ['transform-typeof-symbol'],
-      },
-    ]);
+    // TODO: enable this in more cases based on browserslist
+    if (options.targets && options.targets.esmodules === true) {
+      preset.presets.unshift([
+        require('@babel/preset-modules'),
+        { loose: true },
+      ]);
+    } else {
+      preset.presets.unshift([
+        require('@babel/preset-env').default,
+        {
+          targets: options.targets,
+          modules,
+          useBuiltIns: options.useBuiltIns,
+          corejs: options.corejs,
+          loose: options.loose,
+          // Exclude transforms that make all code slower
+          exclude: ['transform-typeof-symbol'],
+        },
+      ]);
+    }
   }
   if (options.minify && env === 'production') {
     preset.presets.unshift(require('babel-minify'));

--- a/packages/babel-preset-anansi/package.json
+++ b/packages/babel-preset-anansi/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/plugin-transform-typescript": "^7.7.2",
     "@babel/preset-env": "^7.7.1",
+    "@babel/preset-modules": "^0.1.0",
     "@babel/preset-react": "^7.7.0",
     "babel-minify": "^0.5.1",
     "babel-plugin-dynamic-import-node": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,6 +1621,17 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-flow-strip-types" "^7.0.0"
 
+"@babel/preset-modules@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.0.tgz#bbf47ed5530f8d663f0eb1c592864964b7cdaead"
+  integrity sha512-6t3sNgGW4AhaR71sfXCVUq/4BlWDn1QhRbECD6CMPkMPxUhj66d1ss7xllftdi4WnrJWJ1RD3jDQnEqMcAFd5g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/preset-react@7.0.0", "@babel/preset-react@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"


### PR DESCRIPTION
https://github.com/babel/preset-modules was released today and announced at google dev summit. It produces more streamlined output by attempting to target es6 rather than es5 in it's transforms.

This currently only uses `preset-modules` instead of `preset-env` if target is set to `{ esmodules: true }` as this is only intended for that specific set of browsers.