### PR TITLE
enhance: Change default production htmlOptions to have empty title

### DIFF
--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -19,7 +19,7 @@ export default function makeProdConfig(
     libraryInclude,
     libraryExclude,
     argv = {},
-    htmlOptions = { title: 'Anansi app' },
+    htmlOptions = { title: '' },
   },
 ) {
   const config = { ...baseConfig };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9197,9 +9197,9 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.1.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
-  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Development having a fallback title can be useful to more obviously catch but in production it's best to have something safe like empty string.