### PR TITLE
[TASK] Add babelRoot to webpack config generator

### DIFF
--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -135,7 +135,7 @@ from any file.
 
 ## babelRoot = \$CWD
 
-babelRoot should be where the root babel configuration file is in your repo. Usually this is CWD, but while setting up a monorepo with multiple babel configurations, you may need to change this value.
+`babelRoot` should be where the root babel configuration file is in your repo. Usually this is CWD, but while setting up a monorepo with multiple babel configurations, you may need to change this value.
 
 ### rootPath = \$CWD
 

--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -7,11 +7,11 @@ A webpack configuration for fast development and production ready optimizations
 `/webpack.config.js`
 
 ```javascript
-const { makeConfig } = require("@anansi/webpack-config");
+const { makeConfig } = require('@anansi/webpack-config');
 
 const options = {
-  basePath: "src",
-  buildDir: "generated_assets/"
+  basePath: 'src',
+  buildDir: 'generated_assets/',
 };
 
 module.exports = { options };
@@ -37,8 +37,8 @@ module.exports = makeConfig(options);
 `/.storybook/webpack.config.js`
 
 ```js
-const { makeStorybookConfigGenerator } = require("@anansi/webpack-config");
-const { options } = require("../webpack.config");
+const { makeStorybookConfigGenerator } = require('@anansi/webpack-config');
+const { options } = require('../webpack.config');
 
 module.exports = makeStorybookConfigGenerator(options);
 ```
@@ -106,7 +106,7 @@ To match all libraries in namespace `@myspacespace`:
 const myConfig = makeConfig({
   libraryInclude: /node_modules\/(@mynamespace\/)/,
   libraryExclude: /node_modules(?!\/(@mynamespace\/))/,
-})
+});
 ```
 
 ### basePath = 'src'
@@ -128,10 +128,14 @@ Example:
 Then you can do
 
 ```javascript
-import fetch from "network";
+import fetch from 'network';
 ```
 
 from any file.
+
+## babelRoot = \$CWD
+
+babelRoot should be where the root babel configuration file is in your repo. Usually this is CWD, but while setting up a monorepo with multiple babel configurations, you may need to change this value.
 
 ### rootPath = \$CWD
 

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anansi/webpack-config",
-  "version": "0.19.1",
+  "version": "0.18.1",
   "description": "Webpack config",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anansi/webpack-config",
-  "version": "0.18.1",
+  "version": "0.19.1",
   "description": "Webpack config",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -14,6 +14,7 @@ export default function makeBaseConfig({
   basePath,
   libraryInclude,
   libraryExclude,
+  babelRoot,
   buildDir,
   mode,
   manifestFilename,
@@ -21,6 +22,7 @@ export default function makeBaseConfig({
   const babelLoader = {
     loader: 'babel-loader',
     options: {
+      cwd: path.resolve(process.cwd(), babelRoot),
       cacheDirectory: true,
       cacheCompression: mode === 'production',
       compact: mode === 'production',


### PR DESCRIPTION
This is the directory that babel takes as the root directory when deciding which configuration file to use.