### PR TITLE
enhance: Let preset-env handle dynamic imports

### DIFF
--- a/packages/babel-preset-anansi/index.js
+++ b/packages/babel-preset-anansi/index.js
@@ -14,10 +14,6 @@ options:
 */
 function buildPreset(api, options = {}) {
   const env = api.env();
-  // if undefined, we know nothing about their support
-  const supportsDynamicImport = api.caller(
-    caller => caller && caller.supportsDynamicImport,
-  );
   const supportsModules = api.caller(
     caller => caller && caller.supportsStaticESM,
   );
@@ -147,10 +143,6 @@ function buildPreset(api, options = {}) {
         useBuiltIns: false,
       },
     ]);
-    // since this is a node-specific plugin we need to be sure we're running in node
-    if (supportsDynamicImport !== true) {
-      preset.plugins.push(require('babel-plugin-dynamic-import-node'));
-    }
   } else {
     // TODO: enable this in more cases based on browserslist
     if (options.targets && options.targets.esmodules === true) {

--- a/packages/babel-preset-anansi/package.json
+++ b/packages/babel-preset-anansi/package.json
@@ -43,7 +43,6 @@
     "@babel/preset-modules": "^0.1.2",
     "@babel/preset-react": "^7.8.0",
     "babel-minify": "^0.5.1",
-    "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-macros": "^2.8.0",
     "babel-plugin-ramda": "^2.0.0",


### PR DESCRIPTION
https://babeljs.io/blog/2019/07/03/7.5.0#dynamic-import-9552-https-githubcom-babel-babel-pull-9552-and-10109-https-githubcom-babel-babel-pull-10109

Since 7.5, preset-env now does similar detection for dynamic imports. However, it supports more module targets than just commonjs so this is more powerful.

It does the same detection algorithm to understand when things like webpack and parcel and using it so as to let them perform the transform.