### PR TITLE
fix: Include needed peerdeps from eslint-plugin

### DIFF
--- a/packages/generator-js/package.json
+++ b/packages/generator-js/package.json
@@ -41,7 +41,6 @@
     "yeoman-generator"
   ],
   "devDependencies": {
-    "@anansi/eslint-plugin": "^0.8.3",
     "@types/ejs": "^3.0.0",
     "@types/node": "^12.12.16",
     "@types/yeoman-generator": "^3.1.4",
@@ -61,6 +60,7 @@
     "npm": ">= 4.0.0"
   },
   "dependencies": {
+    "@anansi/eslint-plugin": "^0.8.3",
     "@anansi/webpack-config": "^0.19.4",
     "@babel/core": "^7.7.7",
     "@types/mem-fs-editor": "^5.1.1",


### PR DESCRIPTION
Fixes #25 

installPeers() requires the package to be installed to inspect the package.json