### PR TITLE
enhance: Use TypeScript 4.1 jsx transform support

### DIFF
--- a/packages/generator-js/src/base/index.ts
+++ b/packages/generator-js/src/base/index.ts
@@ -96,7 +96,7 @@ export default class extends InstallPeersMixin(ConfigureGenerator) {
   }
 
   installTypeScript() {
-    this.yarnInstall(['typescript', '@anansi/eslint-plugin'], {
+    this.yarnInstall(['typescript@beta', '@anansi/eslint-plugin'], {
       dev: true,
     });
   }

--- a/packages/generator-js/src/base/templates/tsconfig.json
+++ b/packages/generator-js/src/base/templates/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "esnext",
     "module": "esnext",
     "lib": ["dom", "esnext"],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "declaration": true,
     "strict": true,
     "moduleResolution": "node",

--- a/packages/generator-js/src/spa/templates/src/index.tsx
+++ b/packages/generator-js/src/spa/templates/src/index.tsx
@@ -1,4 +1,4 @@
-import React<% if (reactMode === 'legacy') { %>, { StrictMode }<% } %> from 'react';
+<% if (reactMode === 'legacy') { %>import { StrictMode } from 'react';<% } %>
 import ReactDOM from 'react-dom';
 
 import RootProvider from './RootProvider';


### PR DESCRIPTION
Land this when 4.1 is out: https://github.com/microsoft/TypeScript/issues/40124 Nov 17

This eliminates the error when React import is missing in tsx files