### PR TITLE
fix: Use normal node resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
       "examples/*"
     ],
     "nohoist": [
-      "**/@storybook/**"
+      "**/@storybook/**",
+      "react",
+      "react-dom"
     ]
   },
   "scripts": {

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -190,7 +190,6 @@ export default function makeBaseConfig({
       modules: [
         path.join(rootPath, basePath),
         path.join(rootPath, basePath, 'style'),
-        path.join(rootPath, 'node_modules'),
         'node_modules',
       ],
       extensions: ['.js', '.ts', '.tsx', '.scss', '.json'],


### PR DESCRIPTION
After further testing https://github.com/ntucker/anansi/pull/49 sometimes results in packages being unable to resolve their dependencies in cases where their dependencies get hoisted.

My conclusion is it's best not to mess with module resolution behavior, but rather focus on the really problem - hoisting. As far as I can tell peerDeps will still work correctly, so by eliminating hoisting where:

- packages might have multiple versions in the monorepo
- yet only one version should be loaded for a given application

If we ensure those packages never get hoisted, then it will always resolve to the local application one. It is important to use peerdeps in these cases, or other packages might end up pointing to a different version. However, this is already required when using packages externally so it's more of an additional testing guard than a limitation.