### PR TITLE
fix: Use webpack 4 if storybook is used

### DIFF
--- a/packages/generator-js/src/base/index.ts
+++ b/packages/generator-js/src/base/index.ts
@@ -37,6 +37,7 @@ export default class extends InstallPeersMixin(ConfigureGenerator) {
       this.composeWith(require.resolve('../library'), this.options);
     }
     if (props.features.includes('storybook')) {
+      this.config.set('webpack-version', '4');
       this.composeWith(require.resolve('../storybook'), this.options);
     }
     return props;
@@ -96,7 +97,7 @@ export default class extends InstallPeersMixin(ConfigureGenerator) {
   }
 
   installTypeScript() {
-    this.yarnInstall(['typescript@beta', '@anansi/eslint-plugin'], {
+    this.yarnInstall(['typescript', '@anansi/eslint-plugin'], {
       dev: true,
     });
   }

--- a/packages/generator-js/src/spa/index.ts
+++ b/packages/generator-js/src/spa/index.ts
@@ -81,9 +81,9 @@ module.exports = class extends InstallPeersMixin(BetterGenerator) {
 
   installReact() {
     if (this.config.get('reactMode') === 'legacy') {
-      this.yarnInstall(['react', 'react-dom']);
+      this.yarnInstall(['react', 'react-dom', 'react-test-renderer']);
     } else {
-      this.yarnInstall(['react@experimental', 'react-dom@experimental']);
+      this.yarnInstall(['react@experimental', 'react-dom@experimental', 'react-test-renderer@experimetnal']);
     }
     this.yarnInstall(['@types/react', '@types/react-dom'], { dev: true });
   }

--- a/packages/generator-js/src/spa/index.ts
+++ b/packages/generator-js/src/spa/index.ts
@@ -83,7 +83,7 @@ module.exports = class extends InstallPeersMixin(BetterGenerator) {
     if (this.config.get('reactMode') === 'legacy') {
       this.yarnInstall(['react', 'react-dom', 'react-test-renderer']);
     } else {
-      this.yarnInstall(['react@experimental', 'react-dom@experimental', 'react-test-renderer@experimetnal']);
+      this.yarnInstall(['react@experimental', 'react-dom@experimental', 'react-test-renderer@experimental']);
     }
     this.yarnInstall(['@types/react', '@types/react-dom'], { dev: true });
   }

--- a/packages/generator-js/src/storybook/templates/.storybook/main.js
+++ b/packages/generator-js/src/storybook/templates/.storybook/main.js
@@ -6,4 +6,7 @@ module.exports = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },
+  reactOptions: {
+    fastRefresh: true,
+  },
 };

--- a/packages/generator-js/src/webpack/index.ts
+++ b/packages/generator-js/src/webpack/index.ts
@@ -77,10 +77,13 @@ class WebpackGenerator extends InstallPeersMixin(BetterGenerator) {
 
   installConfig() {
     this.installPeers('@anansi/webpack-config', [], { dev: true });
+    if (this.config.get('webpack-version')) {
+      this.yarnInstall(`webpack@^${this.config.get('webpack-version')}`, { dev: true });
+    }
     const devDeps = [
       '@anansi/webpack-config',
-      'webpack-cli@4',
-      'webpack-dev-server@3',
+      'webpack-cli@^4',
+      'webpack-dev-server@^3',
     ];
     if (this?.props?.style === 'linaria') {
       devDeps.push('linaria');


### PR DESCRIPTION
Storybook currently does not support webpack 5, so if this feature is used we should ensure v4 is installed instead.

### Testing:

- Built new project using storybook feature only.