### PR TITLE
run commitlint on merge

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,8 +1,10 @@
 name: Lint Commit Messages
+
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types: [closed]
+
+if: github.event.pull_request.merged == true
 
 jobs:
   commitlint:


### PR DESCRIPTION
Hopefully this blocks merge completing.

Based on: https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/4