### PR TITLE
enhance: Remove need for fancy loader resolution

### DIFF
--- a/packages/webpack-config-anansi/src/base/constants.js
+++ b/packages/webpack-config-anansi/src/base/constants.js
@@ -1,10 +1,3 @@
 import path from 'path';
 
-import pkg from '../../package.json';
-
 export const ROOT_PATH = path.resolve();
-export const LIBRARY_MODULES_PATH = path.join(
-  'node_modules',
-  pkg.name,
-  'node_modules',
-);

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -4,7 +4,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack from 'webpack';
 import semver from 'semver';
 
-import { ROOT_PATH, LIBRARY_MODULES_PATH } from './constants';
+import { ROOT_PATH } from './constants';
 import { NODE_ALIAS } from './node-polyfill';
 
 export { default as getStyleRules } from './scss';
@@ -201,12 +201,6 @@ export default function makeBaseConfig({
       ],
       extensions: ['.js', '.ts', '.tsx', '.scss', '.json'],
       alias: webpack.version.startsWith('4') ? {} : NODE_ALIAS,
-    },
-    // include the loaders installed by this library
-    resolveLoader: {
-      modules: ['node_modules'],
-      extensions: ['.js', '.ts', '.tsx', '.json'],
-      mainFields: ['loader', 'main'],
     },
     devtool: 'source-map',
     stats: {

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -29,7 +29,7 @@ export default function makeBaseConfig({
     paths: [rootPath],
   }));
   const babelLoader = {
-    loader: 'babel-loader',
+    loader: require.resolve('babel-loader'),
     options: {
       cwd: path.resolve(process.cwd(), babelRoot),
       cacheDirectory: true,
@@ -83,7 +83,10 @@ export default function makeBaseConfig({
           test: /\.worker\.(t|j)s$/,
           use: [
             babelLoader,
-            { loader: 'worker-loader', options: { inline: 'fallback' } },
+            {
+              loader: require.resolve('worker-loader'),
+              options: { inline: 'fallback' },
+            },
           ],
           include: [
             new RegExp(basePath),
@@ -95,7 +98,11 @@ export default function makeBaseConfig({
         },
         {
           test: /\.(t|j)sx?$/,
-          use: ['thread-loader', babelLoader, ...extraJsLoaders],
+          use: [
+            require.resolve('thread-loader'),
+            babelLoader,
+            ...extraJsLoaders,
+          ],
           include: [
             new RegExp(basePath),
             path.join(rootPath, 'stories'),
@@ -106,7 +113,7 @@ export default function makeBaseConfig({
         },
         {
           test: /\.(md|txt)$/,
-          use: 'raw-loader',
+          use: require.resolve('raw-loader'),
         },
         {
           test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
@@ -115,7 +122,7 @@ export default function makeBaseConfig({
           },
           use: [
             {
-              loader: '@svgr/webpack',
+              loader: require.resolve('@svgr/webpack'),
               options: {
                 svgoConfig: {
                   plugins: [
@@ -128,7 +135,7 @@ export default function makeBaseConfig({
               },
             },
             {
-              loader: 'file-loader',
+              loader: require.resolve('file-loader'),
               options: {
                 name:
                   mode === 'production'
@@ -146,7 +153,7 @@ export default function makeBaseConfig({
           },
           use: [
             {
-              loader: 'file-loader',
+              loader: require.resolve('file-loader'),
               options: {
                 name:
                   mode === 'production'
@@ -160,7 +167,7 @@ export default function makeBaseConfig({
           test: /\.(png|jpg|gif|ico|webp|avif|otf|eot|woff2|woff|ttf)(\?v=\d+\.\d+\.\d+)?$/,
           use: [
             {
-              loader: 'file-loader',
+              loader: require.resolve('file-loader'),
               options: {
                 name:
                   mode === 'production'
@@ -174,7 +181,7 @@ export default function makeBaseConfig({
           test: /\.(pdf|mp4|webm|wav|mp3|m4a|aac|oga)(\?v=\d+\.\d+\.\d+)?$/,
           use: [
             {
-              loader: 'url-loader',
+              loader: require.resolve('url-loader'),
               options: {
                 name:
                   mode === 'production'
@@ -197,7 +204,7 @@ export default function makeBaseConfig({
     },
     // include the loaders installed by this library
     resolveLoader: {
-      modules: [LIBRARY_MODULES_PATH, 'node_modules'],
+      modules: ['node_modules'],
       extensions: ['.js', '.ts', '.tsx', '.json'],
       mainFields: ['loader', 'main'],
     },

--- a/packages/webpack-config-anansi/src/base/scss.js
+++ b/packages/webpack-config-anansi/src/base/scss.js
@@ -11,11 +11,11 @@ const getCSSLoaders = ({ mode }) => {
       options: {},
     },
     {
-      loader: 'css-loader',
+      loader: require.resolve('css-loader'),
       options: {},
     },
     {
-      loader: 'postcss-loader',
+      loader: require.resolve('postcss-loader'),
       options: {
         postcssOptions: {
           plugins: [autoprefixer(), cssPresetEnv()],
@@ -29,13 +29,13 @@ const getCSSLoaders = ({ mode }) => {
 const getSASSLoaders = ({ sassResources }) => {
   const loaders = [
     {
-      loader: 'sass-loader',
+      loader: require.resolve('sass-loader'),
       options: { sassOptions: { outputStyle: 'expanded' } },
     },
   ];
   if (sassResources) {
     loaders.push({
-      loader: 'sass-resources-loader',
+      loader: require.resolve('sass-resources-loader'),
       options: {
         resources: sassResources,
       },
@@ -56,7 +56,7 @@ export default function getStyleRules({
   const absoluteBasePath = path.join(rootPath, basePath);
   const cssLoaders = getCSSLoaders({ mode });
   const cssModuleLoaders = cssLoaders.map(loader => {
-    if (loader.loader === 'css-loader') {
+    if (/($|\/)css-loader/.test(loader.loader)) {
       return {
         ...loader,
         options: {
@@ -106,7 +106,7 @@ export default function getStyleRules({
       test: /\.css$/i,
       include: [/node_modules/],
       use: cssModuleLoaders.slice(0, -1).map(loader => {
-        if (loader.loader === 'css-loader') {
+        if (/($|\/)css-loader/.test(loader.loader)) {
           return {
             ...loader,
             options: {

--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -68,7 +68,7 @@ export default function makeProdConfig(
     enforce: 'pre',
     use: [
       {
-        loader: 'svgo-loader',
+        loader: require.resolve('svgo-loader'),
         options: {
           plugins: [
             { removeTitle: false },

--- a/packages/webpack-config-anansi/src/storybook.js
+++ b/packages/webpack-config-anansi/src/storybook.js
@@ -75,7 +75,7 @@ export default function makeStorybookConfigGenerator(baseConfig) {
             // don't use thread-loader
             ...envConfig.module.rules[1],
             use: envConfig.module.rules[1].use.filter(
-              l => l !== 'thread-loader',
+              l => !RegExp(`($|/)${'thread-loader'}`, 'g').test(l),
             ),
           },
           // storybook node_module compiles

--- a/packages/webpack-config-anansi/src/storybook.js
+++ b/packages/webpack-config-anansi/src/storybook.js
@@ -75,7 +75,7 @@ export default function makeStorybookConfigGenerator(baseConfig) {
             // don't use thread-loader
             ...envConfig.module.rules[1],
             use: envConfig.module.rules[1].use.filter(
-              l => !(/($|/)thread-loader/g).test(l),
+              l => !/($|\/)thread-loader/g.test(l),
             ),
           },
           // storybook node_module compiles

--- a/packages/webpack-config-anansi/src/storybook.js
+++ b/packages/webpack-config-anansi/src/storybook.js
@@ -75,7 +75,7 @@ export default function makeStorybookConfigGenerator(baseConfig) {
             // don't use thread-loader
             ...envConfig.module.rules[1],
             use: envConfig.module.rules[1].use.filter(
-              l => !RegExp(`($|/)${'thread-loader'}`, 'g').test(l),
+              l => !(/($|/)thread-loader/g).test(l),
             ),
           },
           // storybook node_module compiles

--- a/packages/webpack-config-anansi/src/utils.js
+++ b/packages/webpack-config-anansi/src/utils.js
@@ -1,6 +1,6 @@
 function setLoaderOptions(config, loaderName, options) {
   const transform = loader => {
-    if (loader === loaderName) {
+    if (RegExp(`($|/)${loaderName}`, 'g').test(loader)) {
       return {
         loader,
         options,


### PR DESCRIPTION
To ensure the loaders from this package are used, a special `resolveLoader` config is set.

This is not ideal for two reasons:
- makes that option fragile against user change
- the option itself could potentially break apart.

Here we use require.resolve() to ensure absolute paths for all loaders we specify. This should be strong against any other configs - so long as these are not modified.

This means we need to be a bit more fancy with our loader matching algo - so we use a regex.

Bonus: this also makes this compatible with `PnpWebpackPlugin`


### Testing

Verified this would resolve correctly still in an independent project by modifying its lib source directly.