### PR TITLE
feat: Add import aliasing options

### DIFF
--- a/packages/babel-preset-anansi/README.md
+++ b/packages/babel-preset-anansi/README.md
@@ -1,4 +1,5 @@
 # Anansi's React Babel Preset
+
 [![CircleCI](https://circleci.com/gh/ntucker/anansi.svg?style=shield)](https://circleci.com/gh/ntucker/anansi)
 [![npm downloads](https://img.shields.io/npm/dm/@anansi/babel-preset.svg?style=flat-square)](https://www.npmjs.com/package/@anansi/babel-preset)
 [![npm version](https://img.shields.io/npm/v/@anansi/babel-preset.svg?style=flat-square)](https://www.npmjs.com/package/@anansi/babel-preset)
@@ -120,6 +121,74 @@ Be sure to install babel-minify as it is listed as an optional peerdependency he
 - all things in preset-env
 - legacy decorators
 
+### reactRequire: bool = true
+
+Automatically add react import if JSX is used.
+
+### hotReloader: boolean = false
+
+Using react-hot-reloader instead of react-refresh
+
+### reactConstantElementsOptions: { allowMutablePropsOnTags?: string[] } | false
+
+Configures the options for [react-constant-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements).
+Setting to false disables this optimization altogether. Note: this is only ever used in production mode
+
+### hasJsxRuntime
+
+Use [new jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Available in React >16.14.
+
+- With the new transform, you can use JSX without importing React.
+- Depending on your setup, its compiled output may slightly improve the bundle size.
+- It will enable future improvements that reduce the number of concepts you need to learn React.
+
+> Note: This is automatically set when using anansi webpack using the [caller config](https://babeljs.io/docs/en/options#caller)
+
+## module-resolver options
+
+### resolverRoot
+
+Sets the root [root](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md#root).
+
+```js
+root = ['./src'];
+```
+
+#### RESOLVER_ROOT
+
+Overrides `resolverRoot`.
+
+```bash
+export RESOLVER_ROOT = './src'
+```
+
+### resolverAlias
+
+JSON representation of the [alias](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md#alias) object option.
+
+```js
+{
+  "underscore": "lodash",
+  "^@namespace/foo-(.+)": "packages/\\1"
+}
+```
+
+#### RESOLVER_ALIAS
+
+If `RESOLVER_ALIAS` env is set, it will override this setting. Be sure to JSON encode.
+
+```bash
+export RESOLVER_ALIAS = '{"underscore":"lodash","^@namespace/foo-(.+)":"packages/\\\\1"}'
+```
+
+### resolver
+
+Full control of [module-resolver options](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md).
+Sets as default, so `resolverRoot` and `resolverAlias` will override `root` and `alias` respectively.
+
+## root-import options
+
 ### rootPathSuffix: string = './src'
 
 Enables importing from project root with `~/my/path` rather than using relative paths. Override
@@ -147,31 +216,6 @@ No value (undefined) means use current working directory.
 
 Sending `__dirname` from a `.babelrc.js` can be useful to ensure consistency no matter
 where babel starts running from.
-
-### reactRequire: bool = true
-
-Automatically add react import if JSX is used.
-
-### hotReloader: boolean = false
-
-Using react-hot-reloader instead of react-refresh
-
-### reactConstantElementsOptions: { allowMutablePropsOnTags?: string[] } | false
-
-Configures the options for [react-constant-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements).
-Setting to false disables this optimization altogether. Note: this is only ever used in production mode
-
-### hasJsxRuntime
-
-Use [new jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
-Available in React >16.14.
-
-- With the new transform, you can use JSX without importing React.
-- Depending on your setup, its compiled output may slightly improve the bundle size.
-- It will enable future improvements that reduce the number of concepts you need to learn React.
-
-> Note: This is automatically set when using anansi webpack using the [caller config](https://babeljs.io/docs/en/options#caller)
-
 
 ## Future language support
 

--- a/packages/babel-preset-anansi/index.js
+++ b/packages/babel-preset-anansi/index.js
@@ -75,6 +75,19 @@ function buildPreset(api, options = {}) {
     ],
     plugins: [
       [
+        require('babel-plugin-module-resolver').default,
+        {
+          ...options.resolver,
+          root: process.env.RESOLVER_ROOT
+            ? [process.env.RESOLVER_ROOT]
+            : options.resolverRoot,
+          alias:
+            (process.env.RESOLVER_ALIAS &&
+              JSON.parse(process.env.RESOLVER_ALIAS)) ||
+            options.resolverAlias,
+        },
+      ],
+      [
         require('babel-plugin-root-import').default,
         {
           root: process.env.ROOT_PATH_ROOT || options.rootPathRoot,

--- a/packages/babel-preset-anansi/package.json
+++ b/packages/babel-preset-anansi/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-react": "^7.12.13",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-macros": "^3.0.1",
+    "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-ramda": "^2.0.0",
     "babel-plugin-react-require": "^3.1.3",
     "babel-plugin-root-import": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6146,6 +6146,17 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
+babel-plugin-module-resolver@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz#22a4f32f7441727ec1fbf4967b863e1e3e9f33e2"
+  integrity sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz#c9750a1b38d85112c9e166bf3ef7c5dbc605f4be"
@@ -10242,6 +10253,14 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -13107,7 +13126,7 @@ json3@^3.3.3:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -18129,6 +18148,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Aliasing is useful for the new package.json exports:

```bash
RESOLVER_ALIAS='{"@rest-hooks/test":"#internal"}' yarn build:lib
```

### Testing

- Manually pasted the code into node_modules in rest-hooks, tried env variables
- Test existing features via anansi example builds