### PR TITLE
feat: Add --env nohash option

### DIFF
--- a/.github/workflows/bundle_size.yml
+++ b/.github/workflows/bundle_size.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
     - uses: actions/checkout@v2-beta
       with:
         fetch-depth: 1
@@ -16,6 +19,6 @@ jobs:
       continue-on-error: true
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        build-script: "lerna run --ignore anansi-example-linaria --ignore @anansi/generator-js build"
+        build-script: "build:sizecompare"
         pattern: "examples/typescript/dist/**/*.{js,css,html,json}"
         exclude: "{examples/typescript/dist/manifest.json,**/*.map,**/node_modules/**}"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,17 +9,16 @@ jobs:
         with:
           fetch-depth: 0
       - run: mkdir /tmp/artifacts
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - name: install and build
         run: |
           yarn
-          yarn build
+          yarn build:sizecompare
       - name: run Lighthouse CI
         working-directory: ./examples/typescript
         run: |
-          npm install -g @lhci/cli@0.6.x
-          lhci autorun
+          npx @lhci/cli@0.7.x autorun
         env:
           LHCI_GITHUB_TOKEN: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "release": "lerna publish",
     "build": "lerna run build --stream",
-    "prepare": "husky install"
+    "build:sizecompare": "yarn workspace anansi-example-typescript build --env nohash",
+    "prepare": "husky install && yarn lerna run build --ignore anansi-example-linaria --ignore anansi-example-typescript"
   },
   "devDependencies": {
     "@anansi/eslint-plugin": "^0.10.6",

--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -168,6 +168,16 @@ server for SSR alongside the client bundle.
 
 `webpack --mode=production --target=node`
 
+### nohash
+
+This is useful for diffing bundle filesizes as it removes cache busting filenames - keeping the name
+the same as their contents change.
+
+For example [compressed-size-action](https://github.com/preactjs/compressed-size-action) can track bundle size
+changes.
+
+`webpack --mode=production --nohash`
+
 ## ENV customization
 
 Environmental variable control is sometimes useful in CI pipelines

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -26,6 +26,7 @@ export default function makeBaseConfig({
   extraJsLoaders,
   linariaOptions,
   tsconfigPathsOptions,
+  env,
   argv,
 }) {
   const babelLoader = generateBabelLoader({
@@ -59,8 +60,8 @@ export default function makeBaseConfig({
     output: {
       path: path.join(rootPath, buildDir),
       publicPath: WEBPACK_PUBLIC_HOST + WEBPACK_PUBLIC_PATH,
-      filename: '[name]-[contenthash].js',
-      chunkFilename: '[name]-[contenthash].chunk.js',
+      filename: env?.nohash ? '[name].js' : '[name]-[contenthash].js',
+      chunkFilename: env?.nohash ? '[name].chunk.js' : '[name]-[contenthash].chunk.js',
       globalObject: "(typeof self !== 'undefined' ? self : this)",
     },
     cache: {
@@ -80,9 +81,9 @@ export default function makeBaseConfig({
       }),
       new MiniCssExtractPlugin({
         filename:
-          mode !== 'production' ? '[name].css' : '[name].[contenthash].css',
+          mode !== 'production' | env?.nohash ? '[name].css' : '[name].[contenthash].css',
         chunkFilename:
-          mode !== 'production' ? '[name].css' : '[name].[contenthash].css',
+          mode !== 'production' | env?.nohash ? '[name].css' : '[name].[contenthash].css',
       }),
     ],
     module: {
@@ -141,10 +142,11 @@ export default function makeBaseConfig({
             {
               loader: require.resolve('file-loader'),
               options: {
-                name:
-                  mode === 'production'
-                    ? '[name].[contenthash].[ext]'
-                    : '[path][contenthash].[ext]',
+                name: env?.nohash
+                  ? '[name].[ext]'
+                  : mode === 'production'
+                      ? '[name].[contenthash].[ext]'
+                      : '[path][contenthash].[ext]',
               },
             },
           ],


### PR DESCRIPTION
- Build relevant packages in prepare script, so getting started works
- Webpack: add --env nohash that outputs consistent filenames
- build:sizecompare to exploit this for bundlesize checker