### PR TITLE
enhance: Only support TypeScript and default webpack extensions

### DIFF
--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -228,16 +228,7 @@ export default function makeBaseConfig({
     },
     resolve: {
       modules,
-      extensions: [
-        '.wasm',
-        '.mjs',
-        '.js',
-        '.ts',
-        '.tsx',
-        '.cjs',
-        '.scss',
-        '.json',
-      ],
+      extensions: ['.ts', '.tsx', '...'],
       fallback: NODE_ALIAS,
       plugins:
         tsconfigPathsOptions !== false


### PR DESCRIPTION
BREAKING CHANGE: Importing scss file requires including the file
extension