### PR TITLE
fix: Linaria works with svg urls

### DIFF
--- a/examples/linaria/src/App.tsx
+++ b/examples/linaria/src/App.tsx
@@ -3,6 +3,9 @@ import { css } from '@linaria/core';
 import { styled } from '@linaria/react';
 
 import MenuItem from 'MenuItem';
+import Media from 'Media';
+
+import AngleDownUrl from './angle-down-solid.svg';
 
 // Linaria seems very particular about what exactly you can interpolate
 const media = {
@@ -74,6 +77,11 @@ const App = () => (
       <Text>hello world!</Text>
       <MenuItem>hi</MenuItem>
     </Container>
+    <div>
+      <img src={AngleDownUrl} style={{ width: '1em' }} />{' '}
+      {/*<AngleDown style={{ width: '1em' }} />*/}
+    </div>
+    <Media />
   </>
 );
 

--- a/examples/linaria/src/Media.tsx
+++ b/examples/linaria/src/Media.tsx
@@ -1,0 +1,18 @@
+import { styled } from '@linaria/react';
+
+const SvgContainer = styled.div`
+  width: 32px;
+  height: 32px;
+  background: url('angle-down-solid.svg');
+`;
+
+export default function Media() {
+  return (
+    <div>
+      <h3>
+        Hello World <a href="https://true.io">True IO</a>
+      </h3>
+      <SvgContainer>Hi</SvgContainer>
+    </div>
+  );
+}

--- a/examples/linaria/src/angle-down-solid.svg
+++ b/examples/linaria/src/angle-down-solid.svg
@@ -1,0 +1,3 @@
+<svg aria-hidden="true" data-prefix="fas" data-icon="angle-down" class="svg-inline--fa fa-angle-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+<path fill="#f00" d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"></path>
+</svg>

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "@linaria/webpack5-loader": "^3.0.0-beta.17",
+    "@ntucker/linaria-webpack5-loader": "3.0.0-beta.17",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
     "@svgr/webpack": "^6.2.1",
     "@types/webpack-bundle-analyzer": "^4.4.1",

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -41,7 +41,7 @@ export default function makeBaseConfig({
     }
     extraJsLoaders = [
       {
-        loader: require.resolve('@linaria/webpack5-loader'),
+        loader: require.resolve('@ntucker/linaria-webpack5-loader'),
         options: linariaOptions,
       },
       ...extraJsLoaders,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,17 +2574,6 @@
   resolved "https://registry.yarnpkg.com/@linaria/utils/-/utils-3.0.0-beta.15.tgz#001d8dacf113c443960651593144e64bf39e995a"
   integrity sha512-CF0T8ueWjHK8zJT0oqdAq8JgL9a40WCyE5/t6q8WPvC7xRdsrfyUKA7Z8qEsQse2LKESVWJ5cvkkn8J80B6c+A==
 
-"@linaria/webpack5-loader@^3.0.0-beta.17":
-  version "3.0.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@linaria/webpack5-loader/-/webpack5-loader-3.0.0-beta.17.tgz#f8c755fa0033d9e74395f228a25bfa59fb2e12ec"
-  integrity sha512-Th5yIqvxzFJ1NGk3qR2k9fti2erNopypItA4b6A8loyhgH1aYKOPyEvCIJh6Wo2MBouz4zWeNRTQT6NfI36uTA==
-  dependencies:
-    "@linaria/babel-preset" "^3.0.0-beta.17"
-    "@linaria/logger" "^3.0.0-beta.15"
-    enhanced-resolve "^5.3.1"
-    loader-utils "^2.0.0"
-    mkdirp "^0.5.1"
-
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
@@ -2811,6 +2800,20 @@
     "@npmcli/promise-spawn" "^1.3.2"
     node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
+
+"@ntucker/linaria-webpack5-loader@3.0.0-beta.17":
+  version "3.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@ntucker/linaria-webpack5-loader/-/linaria-webpack5-loader-3.0.0-beta.17.tgz#854dd54c39e967c838dd7943eddb42405ed81434"
+  integrity sha512-ByaXr/9dTASmMAaOCb0TRW4Z2i9+7OkoXAQOm60zhdfMOrYZZjNA+Ex/OnOABpaOc0qVx9UzbitAOUXbBurIxw==
+  dependencies:
+    "@linaria/babel-preset" "^3.0.0-beta.17"
+    "@linaria/logger" "^3.0.0-beta.15"
+    cosmiconfig "^5.1.0"
+    enhanced-resolve "^5.3.1"
+    find-yarn-workspace-root "^1.2.1"
+    loader-utils "^2.0.0"
+    mkdirp "^0.5.1"
+    normalize-path "^3.0.0"
 
 "@octokit/auth-token@^2.4.4":
   version "2.4.5"
@@ -9651,6 +9654,14 @@ find-yarn-workspace-root2@1.2.16:
     micromatch "^4.0.2"
     pkg-dir "^4.2.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 first-chunk-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
@@ -9821,6 +9832,15 @@ fs-extra@^10.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
@@ -12664,6 +12684,13 @@ jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
   integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -19877,7 +19904,7 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.2:
+universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==


### PR DESCRIPTION
https://github.com/callstack/linaria/pull/879 breaks a lot of things:

- urls cannot be resolved using webpack resolution rules
- svgr cannot work because issuer queries break and we don't know we should be considering the url from a css source
- react-refresh breaks due to detecting it is in a js file when in fact it's processing css

So we publish a loader where this is reverted.

We also introduce the url-inside linaria use case for an svg with absolute resolution to ensure this is accounted for.

