### PR TITLE
fix: Support webcontainers like stackblitz

### DIFF
--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -166,10 +166,15 @@ export default function makeBaseConfig({
               // TODO: Remove when we stop supporting linaria betas
               exclude: /\.linaria-cache/,
               use: [
-                {
-                  loader: require.resolve('thread-loader'),
-                  options: {},
-                },
+                Object.prototype.hasOwnProperty.call(
+                  process.versions,
+                  'webcontainer',
+                )
+                  ? undefined
+                  : {
+                      loader: require.resolve('thread-loader'),
+                      options: {},
+                    },
                 generateBabelLoader({
                   rootPath,
                   babelRoot,
@@ -178,7 +183,7 @@ export default function makeBaseConfig({
                   babelLoaderOptions,
                 }),
                 ...extraJsLoaders,
-              ],
+              ].filter(l => l),
             },
           ],
         },


### PR DESCRIPTION
Threads don't work in webcontainers, so when that environment is detected, don't use thread-loader.