### PR TITLE
enhance: Remove thread-loader

### DIFF
--- a/.github/workflows/bundle_size.yml
+++ b/.github/workflows/bundle_size.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: 16.x
     - uses: actions/checkout@v2-beta
       with:
         fetch-depth: 1

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -117,7 +117,6 @@
     "svgo": "^2.8.0",
     "svgo-loader": "^3.0.0",
     "terser-webpack-plugin": "^5.3.1",
-    "thread-loader": "^3.0.4",
     "timers-browserify": "^2.0.12",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tty-browserify": "^0.0.1",

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -40,6 +40,10 @@ export default function makeBaseConfig({
     // TODO: remove '.js', '.json', '.wasm' once '...' is well supported in plugins like linaria
     extensions: ['.ts', '.tsx', '.js', '.json', '.wasm', '...'],
     fallback: NODE_ALIAS,
+    plugins:
+      tsconfigPathsOptions !== false
+        ? [new TsconfigPathsPlugin(tsconfigPathsOptions)]
+        : [],
   };
 
   if (linariaOptions !== false) {
@@ -56,18 +60,11 @@ export default function makeBaseConfig({
     extraJsLoaders = [
       {
         loader: require.resolve('@ntucker/linaria-webpack5-loader'),
-        options: { resolveOptions: { ...resolve }, ...linariaOptions },
+        options: { ...linariaOptions },
       },
       ...extraJsLoaders,
     ];
   }
-  // TODO: enhance-resolve is somehow getting spread of this instead of the instance, which
-  // makes the plugin break when using linaria
-  // Once this is resolved, we can allow this interaction with linaria files
-  resolve.plugins =
-    tsconfigPathsOptions !== false
-      ? [new TsconfigPathsPlugin(tsconfigPathsOptions)]
-      : [];
 
   if (globalStyleDir) {
     modules.splice(1, 0, path.join(rootPath, basePath, globalStyleDir));
@@ -171,15 +168,6 @@ export default function makeBaseConfig({
               // TODO: Remove when we stop supporting linaria betas
               exclude: /\.linaria-cache/,
               use: [
-                Object.prototype.hasOwnProperty.call(
-                  process.versions,
-                  'webcontainer',
-                )
-                  ? undefined
-                  : {
-                      loader: require.resolve('thread-loader'),
-                      options: {},
-                    },
                 generateBabelLoader({
                   rootPath,
                   babelRoot,

--- a/packages/webpack-config-anansi/src/storybook.js
+++ b/packages/webpack-config-anansi/src/storybook.js
@@ -97,21 +97,8 @@ export default function makeStorybookConfigGenerator(baseConfig) {
       module: {
         ...envConfig.module,
         rules: [
-          {
-            // don't use thread-loader
-            ...envConfig.module.rules[0],
-            oneOf: [
-              //web workers
-              envConfig.module.rules[0].oneOf[0],
-              //normal js/ts
-              {
-                ...envConfig.module.rules[0].oneOf[1],
-                use: envConfig.module.rules[0].oneOf[1].use.filter(
-                  l => !/($|\/)thread-loader/g.test(l.loader),
-                ),
-              },
-            ],
-          },
+          // js rules (worker and normal)
+          envConfig.module.rules[0],
           // storybook node_module compiles
           libraryRule,
           // the rest of our rules

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,7 +286,6 @@ __metadata:
     svgo: ^2.8.0
     svgo-loader: ^3.0.0
     terser-webpack-plugin: ^5.3.1
-    thread-loader: ^3.0.4
     timers-browserify: ^2.0.12
     tsconfig-paths-webpack-plugin: ^3.5.2
     tty-browserify: ^0.0.1
@@ -17611,7 +17610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-runner@npm:^4.1.0, loader-runner@npm:^4.2.0":
+"loader-runner@npm:^4.2.0":
   version: 4.2.0
   resolution: "loader-runner@npm:4.2.0"
   checksum: e61aea8b6904b8af53d9de6f0484da86c462c0001f4511bedc837cec63deb9475cea813db62f702cd7930420ccb0e75c78112270ca5c8b61b374294f53c0cb3a
@@ -26121,21 +26120,6 @@ __metadata:
   version: 5.14.0
   resolution: "textextensions@npm:5.14.0"
   checksum: 1f610ccf2a2c1445fb7156c23b5c8defd608c74e8047df18abd4b9ee44c74d29b453ba104d14c53c91f9026670f7c923114cd12200ee5ec458cc518fd0798c74
-  languageName: node
-  linkType: hard
-
-"thread-loader@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "thread-loader@npm:3.0.4"
-  dependencies:
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^4.1.0
-    loader-utils: ^2.0.0
-    neo-async: ^2.6.2
-    schema-utils: ^3.0.0
-  peerDependencies:
-    webpack: ^4.27.0 || ^5.0.0
-  checksum: 832edc6eac46df148465feb8d3e3e67a30ea82d1d29401ca1c6461d1a0386c6d1fed05739887fc9c69a7d189a68ca1686eaad214f283825e355de9b42663bcf0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Performance analysis in a very large project for both prod builds and initial dev build with no cache shows thread loader with similar performance without. This is best case scenario for thread-loader actually helping.

Thread-loader comes with [problematic limitations](https://webpack.js.org/loaders/thread-loader/#root):

-  Loaders cannot emit files.
-  Loaders cannot use custom loader API (i. e. by plugins).
-  Loaders cannot access the webpack options.

These limitations have caused problems in linaria as well as resolve plugins.

Due to this, we're removing thread loader altogether.