### PR TITLE
feat: SSR uses webpack devserver and responds to code changes

### DIFF
--- a/examples/concurrent/src/app/index.tsx
+++ b/examples/concurrent/src/app/index.tsx
@@ -7,3 +7,4 @@ export const app = (
   </RootProvider>
 );
 export default app;
+export { RootProvider, App };

--- a/examples/concurrent/src/index.tsx
+++ b/examples/concurrent/src/index.tsx
@@ -18,4 +18,4 @@ const spouts = documentSpout({ title: 'anansi' })(
   ),
 );
 
-floodSpouts(spouts);
+export default floodSpouts(spouts);

--- a/examples/concurrent/src/pages/Home/index.tsx
+++ b/examples/concurrent/src/pages/Home/index.tsx
@@ -3,5 +3,5 @@ import { Typography } from 'antd';
 const { Title } = Typography;
 
 export default function Home() {
-  return <Title>hello world2</Title>;
+  return <Title>hello world</Title>;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,10 +71,12 @@
     "@anansi/router": "^0.4.1",
     "@babel/runtime": "^7.10.5",
     "@rest-hooks/ssr": "^0.1.3",
+    "chalk": "^4.0.0",
     "compression": "^1.7.4",
     "cross-fetch": "^3.1.5",
     "express": "^4.17.3",
     "fs-monkey": "^1.0.3",
+    "import-fresh": "^3.3.0",
     "memfs": "^3.4.1",
     "ora": "^5.0.0",
     "redux": "^4.1.2",
@@ -82,14 +84,15 @@
     "source-map-support": "^0.5.21",
     "tmp": "^0.2.1",
     "unionfs": "^4.4.0",
-    "webpack-hot-middleware": "^2.25.1",
+    "webpack-dev-server": "^4.9.0",
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
     "@types/react": "^17.0.40 || ^18.0.0-0",
     "@types/react-dom": "^17.0.40 || ^18.0.0-0",
     "react": "^18.0.0-0",
-    "react-dom": "^18.0.0-0"
+    "react-dom": "^18.0.0-0",
+    "webpack": "^5.60.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/core/src/laySpouts.tsx
+++ b/packages/core/src/laySpouts.tsx
@@ -7,7 +7,7 @@ export default function laySpouts(
   spouts: (props: ServerProps) => Promise<{
     app: JSX.Element;
   }>,
-  { timeoutMS = 1000 }: { timeoutMS?: number } = {},
+  { timeoutMS = 100 }: { timeoutMS?: number } = {},
 ) {
   const render: Render = async (clientManifest, req, res) => {
     const { app } = await spouts({ clientManifest, req, res });

--- a/packages/webpack-config-anansi/src/dev.js
+++ b/packages/webpack-config-anansi/src/dev.js
@@ -1,6 +1,7 @@
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import webpack from 'webpack';
 import path from 'path';
+import logging from 'webpack/lib/logging/runtime';
 
 import ErrorOverlayPlugin from './plugins/ErrorOverlayPlugin';
 import WatchMissingNodeModulesPlugin from './plugins/WatchMissingNodeModulesPlugin';
@@ -132,7 +133,9 @@ export default function makeDevConfig(
         new ErrorOverlayPlugin(),
       );
       config.devServer.hot = 'only';
-      console.log('Fast refresh detected and enabled');
+      logging
+        .getLogger('anansi')
+        .info('React fast refresh detected and enabled');
       // eslint-disable-next-line no-empty
     } catch (e) {}
   }

--- a/packages/webpack-config-anansi/src/plugins/ErrorOverlayEntry.js
+++ b/packages/webpack-config-anansi/src/plugins/ErrorOverlayEntry.js
@@ -27,6 +27,20 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
   );
 });
 
+// Don't show overlay for certain errors as they are disruptive
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', e => {
+    if (
+      e.message.includes(
+        'The server could not finish this Suspense boundary',
+      ) ||
+      e.status
+    ) {
+      e.stopImmediatePropagation();
+    }
+  });
+}
+
 // We need to keep track of if there has been a runtime error.
 // Essentially, we cannot guarantee application state was not corrupted by the
 // runtime error. To prevent confusing behavior, we forcibly reload the entire

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,10 +129,12 @@ __metadata:
     "@types/source-map-support": ^0.5.4
     "@types/tmp": ^0.2.3
     "@types/webpack-hot-middleware": ^2.25.6
+    chalk: ^4.0.0
     compression: ^1.7.4
     cross-fetch: ^3.1.5
     express: ^4.17.3
     fs-monkey: ^1.0.3
+    import-fresh: ^3.3.0
     jest: 28.1.0
     memfs: ^3.4.1
     ora: ^5.0.0
@@ -142,13 +144,14 @@ __metadata:
     source-map-support: ^0.5.21
     tmp: ^0.2.1
     unionfs: ^4.4.0
-    webpack-hot-middleware: ^2.25.1
+    webpack-dev-server: ^4.9.0
     whatwg-fetch: ^3.6.2
   peerDependencies:
     "@types/react": ^17.0.40 || ^18.0.0-0
     "@types/react-dom": ^17.0.40 || ^18.0.0-0
     react: ^18.0.0-0
     react-dom: ^18.0.0-0
+    webpack: ^5.60.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -16001,7 +16004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -28894,7 +28897,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.9.0":
+"webpack-dev-server@npm:4.9.0, webpack-dev-server@npm:^4.9.0":
   version: 4.9.0
   resolution: "webpack-dev-server@npm:4.9.0"
   dependencies:


### PR DESCRIPTION
By forcing one file output bundle for server when using startDevserver; and using `import-fresh` we are able to re-import all output modules on every build change to allow the SSR to get the latest changes. This avoids hydration mismatches as developers edit their code.

Suppress `The server could not finish this Suspense boundary` error from opening overlay as this is expected sometimes depending on desired behavior.