### PR TITLE
enhance: Use lazy-compilation in dev mode for faster build times

### DIFF
--- a/packages/webpack-config-anansi/src/dev.js
+++ b/packages/webpack-config-anansi/src/dev.js
@@ -140,6 +140,11 @@ export default function makeDevConfig(
     } catch (e) {}
   }
 
+  if (!config.experiments) {
+    config.experiments = {};
+  }
+  config.experiments.lazyCompilation = { entries: false };
+
   const styleRules = getStyleRules({
     rootPath,
     basePath,


### PR DESCRIPTION
Compile entrypoints and dynamic imports only when they are in use. 

https://webpack.js.org/configuration/experiments/#experimentslazycompilation