### PR TITLE
feat: Add anansi serve command

### DIFF
--- a/examples/concurrent/package.json
+++ b/examples/concurrent/package.json
@@ -3,8 +3,8 @@
   "version": "2.3.4",
   "private": true,
   "scripts": {
-    "start": "start-anansi ./src/index.tsx",
-    "start:prod": "WEBPACK_PUBLIC_PATH='/assets/' serve-anansi ./dist-server/App.js ./dist/manifest.json",
+    "start": "anansi serve --dev ./src/index.tsx",
+    "start:prod": "anansi serve --pubPath=/assets/ ./dist-server/App.js",
     "start:server": "node ./dist-server/main.js",
     "build": "WEBPACK_PUBLIC_PATH='/assets/' webpack --mode=production",
     "build:server": "WEBPACK_PUBLIC_PATH='/assets/' webpack --mode=production --target=node --env entrypath=index.server.tsx",
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@anansi/babel-preset": "^3.2.2",
     "@anansi/browserslist-config": "^1.3.3",
+    "@anansi/cli": "^1.1.70",
     "@anansi/jest-preset": "^0.7.6",
     "@anansi/webpack-config": "^11.6.1",
     "@rest-hooks/test": "7.3.1",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,3 +58,26 @@ Features can be incrementally adopted by running sub-generators from an existing
 cd my-app-name
 anansi add testing
 ```
+
+## Running SSR
+
+```bash
+Usage: anansi serve [options] <entrypath>
+
+runs server for SSR projects
+
+Arguments:
+  entrypath             Path to entrypoint
+
+Options:
+  -p, --pubPath <path>  Where to serve assets from
+  -d, --dev             Run devserver rather than using previously compiled output
+  -h, --help            display help for command
+```
+
+```json
+{
+  "start": "anansi serve --dev ./src/index.tsx",
+  "start:prod": "anansi serve --pubPath=/assets/ ./dist-server/App.js",
+}
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "jest"
   ],
   "engines": {
-    "node": ">= 12.10.0",
+    "node": ">= 12.20.0",
     "npm": ">= 6.0.0"
   },
   "dependencies": {
@@ -60,6 +60,14 @@
     "mem-fs": "^2.2.1",
     "mem-fs-editor": "^9.4.0",
     "yo": "^4.3.0"
+  },
+  "peerDependencies": {
+    "@anansi/core": "^0.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@anansi/core": {
+      "optional": true
+    }
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/cli/run.js
+++ b/packages/cli/run.js
@@ -102,4 +102,36 @@ program
     }
   });
 
+program
+  .command('serve')
+  .description('runs server for SSR projects')
+  .argument('<entrypath>', 'Path to entrypoint')
+  .option('-p, --pubPath <path>', 'Where to serve assets from')
+  .option(
+    '-d, --dev',
+    'Run devserver rather than using previously compiled output',
+  )
+  .action(async (entrypath, options) => {
+    try {
+      const { serve, devServe } = await import('@anansi/core/scripts');
+
+      if (options.pubPath) process.env.WEBPACK_PUBLIC_PATH = options.pubPath;
+      else if (!process.env.WEBPACK_PUBLIC_PATH)
+        process.env.WEBPACK_PUBLIC_PATH = '/assets/';
+
+      if (options.dev) {
+        devServe(entrypath);
+      } else {
+        serve(entrypath);
+      }
+    } catch (error) {
+      if (error.code === 'ERR_MODULE_NOT_FOUND') {
+        console.error('@anansi/core must be installed to run this subcommand');
+      } else {
+        console.error(error.message);
+      }
+      process.exit(2);
+    }
+  });
+
 program.parse(process.argv);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,10 @@
       "require": "./dist/server.js",
       "default": "./lib/index.server.js"
     },
+    "./scripts": {
+      "types": "./lib/scripts/index.d.ts",
+      "default": "./lib/scripts/index.js"
+    },
     "./package.json": "./package.json"
   },
   "keywords": [

--- a/packages/core/src/scripts/index.ts
+++ b/packages/core/src/scripts/index.ts
@@ -1,0 +1,2 @@
+export { default as serve } from './serve';
+export { default as devServe } from './startDevserver';

--- a/packages/core/src/scripts/serve.ts
+++ b/packages/core/src/scripts/serve.ts
@@ -3,7 +3,7 @@
 import { promisify } from 'util';
 import diskFs from 'fs';
 import path from 'path';
-import webpack from 'webpack';
+import webpack, { web } from 'webpack';
 import { Server, IncomingMessage, ServerResponse } from 'http';
 import express, { NextFunction } from 'express';
 import ora from 'ora';
@@ -12,124 +12,157 @@ import compress from 'compression';
 import 'cross-fetch/polyfill';
 import { Render } from './types';
 
-const entrypoint = process.argv[2];
-const manifestPath = process.argv[3];
-const PORT = process.env.PORT || 8080;
+// run directly from node
+if (require.main === module) {
+  const entrypoint = process.argv[2];
 
-if (!entrypoint || !manifestPath) {
-  console.log(
-    `Usage: ${process.argv[0]} <server-entrypoint> <client-manifest>`,
-  );
-  process.exit(-1);
-}
-
-const loader = ora('Building the assets').start();
-
-const readFile = promisify(diskFs.readFile);
-let server: Server | undefined;
-
-function handleErrors<
-  F extends (
-    req: Request | IncomingMessage,
-    res: Response | ServerResponse,
-  ) => Promise<void>,
->(fn: F) {
-  return async function (
-    req: Request | IncomingMessage,
-    res: Response | ServerResponse,
-    next: NextFunction,
-  ) {
-    try {
-      return await fn(req, res);
-    } catch (x) {
-      next(x);
-    }
-  };
-}
-
-// Start the express server after the first compilation
-function initializeApp(clientManifest: webpack.StatsCompilation) {
-  loader.info('Launching server');
-  if (!clientManifest) {
-    console.log('Manifest not found');
-    // TODO: handle more gracefully
+  if (!entrypoint) {
+    console.log(`Usage: ${process.argv[0]} <server-entrypoint>`);
     process.exit(-1);
   }
-
-  const wrappingApp = express();
-  // eslint-disable-next-line
-  //@ts-ignore
-  wrappingApp.use(compress());
-
-  // ASSETS
-  const assetRoute = async (req: Request | IncomingMessage, res: any) => {
-    const filename =
-      req.url?.substr((process.env.WEBPACK_PUBLIC_PATH as string).length) ?? '';
-    const assetPath = path.join(clientManifest.outputPath ?? '', filename);
-
-    try {
-      const fileContent = (await readFile(assetPath)).toString();
-      res.contentType(filename);
-      res.send(fileContent);
-    } catch (e) {
-      res.status(404);
-      res.send(e);
-      return;
-    }
-  };
-  wrappingApp.get(`${process.env.WEBPACK_PUBLIC_PATH}*`, assetRoute);
-
-  // SERVER SIDE RENDERING
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const render: Render = require(path.join(process.cwd(), entrypoint)).default;
-  wrappingApp.get(
-    '/*',
-    handleErrors(async function (req: any, res: any) {
-      if (req.url.endsWith('favicon.ico')) {
-        res.statusCode = 404;
-        res.setHeader('Content-type', 'text/html');
-        res.send('not found');
-        return;
-      }
-      res.socket.on('error', (error: unknown) => {
-        console.error('Fatal', error);
-      });
-
-      await render(clientManifest, req, res);
-    }),
-  );
-
-  server = wrappingApp
-    .listen(PORT, () => {
-      console.log(`Listening at ${PORT}...`);
-    })
-    .on('error', function (error: any) {
-      if (error.syscall !== 'listen') {
-        throw error;
-      }
-      const isPipe = (portOrPipe: string | number) => Number.isNaN(portOrPipe);
-      const bind = isPipe(PORT) ? 'Pipe ' + PORT : 'Port ' + PORT;
-      switch (error.code) {
-        case 'EACCES':
-          console.error(bind + ' requires elevated privileges');
-          process.exit(1);
-        case 'EADDRINUSE':
-          console.error(bind + ' is already in use');
-          process.exit(1);
-        default:
-          throw error;
-      }
-    });
+  serve(entrypoint);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-initializeApp(require(path.join(process.cwd(), manifestPath)));
+export default function serve(entrypoint: string) {
+  const PORT = process.env.PORT || 8080;
 
-process.on('SIGINT', () => {
-  loader.warn('Received SIGINT, devserver shutting down');
-  if (server) console.log('Closing server');
-  server?.close(() => {
-    loader.info('Server closed');
+  const loader = ora('Initializing').start();
+
+  const manifestPath = getManifestPathFromWebpackconfig();
+
+  const readFile = promisify(diskFs.readFile);
+  let server: Server | undefined;
+
+  function handleErrors<
+    F extends (
+      req: Request | IncomingMessage,
+      res: Response | ServerResponse,
+    ) => Promise<void>,
+  >(fn: F) {
+    return async function (
+      req: Request | IncomingMessage,
+      res: Response | ServerResponse,
+      next: NextFunction,
+    ) {
+      try {
+        return await fn(req, res);
+      } catch (x) {
+        next(x);
+      }
+    };
+  }
+
+  // Start the express server after the first compilation
+  function initializeApp(clientManifest: webpack.StatsCompilation) {
+    loader.info('Launching server');
+    if (!clientManifest) {
+      loader.fail('Manifest not found');
+      // TODO: handle more gracefully
+      process.exit(-1);
+    }
+
+    const wrappingApp = express();
+    // eslint-disable-next-line
+    //@ts-ignore
+    wrappingApp.use(compress());
+
+    // ASSETS
+    const assetRoute = async (req: Request | IncomingMessage, res: any) => {
+      const filename =
+        req.url?.substr((process.env.WEBPACK_PUBLIC_PATH as string).length) ??
+        '';
+      const assetPath = path.join(clientManifest.outputPath ?? '', filename);
+
+      try {
+        const fileContent = (await readFile(assetPath)).toString();
+        res.contentType(filename);
+        res.send(fileContent);
+      } catch (e) {
+        res.status(404);
+        res.send(e);
+        return;
+      }
+    };
+    wrappingApp.get(`${process.env.WEBPACK_PUBLIC_PATH}*`, assetRoute);
+
+    // SERVER SIDE RENDERING
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const render: Render = require(path.join(
+      process.cwd(),
+      entrypoint,
+    )).default;
+    wrappingApp.get(
+      '/*',
+      handleErrors(async function (req: any, res: any) {
+        if (req.url.endsWith('favicon.ico')) {
+          res.statusCode = 404;
+          res.setHeader('Content-type', 'text/html');
+          res.send('not found');
+          return;
+        }
+        res.socket.on('error', (error: unknown) => {
+          console.error('Fatal', error);
+        });
+
+        await render(clientManifest, req, res);
+      }),
+    );
+
+    server = wrappingApp
+      .listen(PORT, () => {
+        loader.info(`Listening at ${PORT}...`);
+      })
+      .on('error', function (error: any) {
+        if (error.syscall !== 'listen') {
+          throw error;
+        }
+        const isPipe = (portOrPipe: string | number) =>
+          Number.isNaN(portOrPipe);
+        const bind = isPipe(PORT) ? 'Pipe ' + PORT : 'Port ' + PORT;
+        switch (error.code) {
+          case 'EACCES':
+            loader.fail(bind + ' requires elevated privileges');
+            process.exit(1);
+          // eslint-disable-next-line no-fallthrough
+          case 'EADDRINUSE':
+            loader.fail(bind + ' is already in use');
+            process.exit(1);
+          // eslint-disable-next-line no-fallthrough
+          default:
+            throw error;
+        }
+      });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  initializeApp(require(manifestPath));
+
+  process.on('SIGINT', () => {
+    loader.warn('Received SIGINT, devserver shutting down');
+    if (server) console.log('Closing server');
+    server?.close(() => {
+      loader.info('Server closed');
+    });
+    process.exit(-1);
   });
-  process.exit(-1);
-});
+}
+
+function getManifestPathFromWebpackconfig() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const webpackConfig: webpack.Configuration = require(require.resolve(
+    // TODO: use normal resolution algorithm to find webpack file
+    path.join(process.cwd(), 'webpack.config'),
+  ))({}, { mode: 'production' });
+  const manifestFilename: string =
+    (
+      webpackConfig?.plugins?.find(plugin => {
+        return plugin.constructor.name === 'StatsWriterPlugin';
+      }) as any
+    )?.opts?.filename ?? 'manifest.json';
+
+  const manifestPath = path.join(
+    webpackConfig?.output?.path ?? '',
+    manifestFilename,
+  );
+  return manifestPath;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,7 +96,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@anansi/cli@workspace:packages/cli":
+"@anansi/cli@^1.1.70, @anansi/cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@anansi/cli@workspace:packages/cli"
   dependencies:
@@ -109,6 +109,11 @@ __metadata:
     mem-fs: ^2.2.1
     mem-fs-editor: ^9.4.0
     yo: ^4.3.0
+  peerDependencies:
+    "@anansi/core": ^0.8.0
+  peerDependenciesMeta:
+    "@anansi/core":
+      optional: true
   bin:
     anansi: ./run.js
   languageName: unknown
@@ -14161,6 +14166,7 @@ __metadata:
   dependencies:
     "@anansi/babel-preset": ^3.2.2
     "@anansi/browserslist-config": ^1.3.3
+    "@anansi/cli": ^1.1.70
     "@anansi/core": ^0.7.4
     "@anansi/jest-preset": ^0.7.6
     "@anansi/router": ^0.5.6


### PR DESCRIPTION
## Command help

```bash
Usage: anansi serve [options] <entrypath>

runs server for SSR projects

Arguments:
  entrypath             Path to entrypoint

Options:
  -p, --pubPath <path>  Where to serve assets from
  -d, --dev             Run devserver rather than using previously compiled output
  -h, --help            display help for command
```

## Usage in package.json

```json
{
  "start": "anansi serve --dev ./src/index.tsx",
  "start:prod": "anansi serve --pubPath=/assets/ ./dist-server/App.js",
}
```
