### PR TITLE
feat: Add CSP support

### DIFF
--- a/examples/concurrent/src/index.server.tsx
+++ b/examples/concurrent/src/index.server.tsx
@@ -5,6 +5,7 @@ import {
   restHooksSpout,
   prefetchSpout,
   routerSpout,
+  JSONSpout,
 } from '@anansi/core/server';
 import React from 'react';
 
@@ -17,10 +18,25 @@ React.useLayoutEffect = React.useEffect;
 
 const appSpout = () => Promise.resolve({ app });
 
+const csPolicy = {
+  'base-uri': "'self'",
+  'object-src': "'none'",
+  'script-src': ["'self'"],
+  'style-src': ["'unsafe-inline'", "'self'"],
+};
+if (process.env.NODE_ENV !== 'production') {
+  csPolicy['script-src'].push("'unsafe-inline'");
+}
+
 const spouts = prefetchSpout('controller')(
-  documentSpout({ title: 'anansi' })(
-    restHooksSpout()(
-      routerSpout({ useResolveWith: useController, createRouter })(appSpout),
+  documentSpout({
+    title: 'anansi',
+    csPolicy,
+  })(
+    JSONSpout()(
+      restHooksSpout()(
+        routerSpout({ useResolveWith: useController, createRouter })(appSpout),
+      ),
     ),
   ),
 );

--- a/examples/concurrent/src/index.tsx
+++ b/examples/concurrent/src/index.tsx
@@ -4,20 +4,23 @@ import {
   documentSpout,
   restHooksSpout,
   routerSpout,
+  JSONSpout,
 } from '@anansi/core';
 
 import app from 'app';
 
 import { createRouter } from './routing';
 
-const appSpout = () => Promise.resolve({ app });
+const appSpout = (v: unknown) => Promise.resolve({ app });
 
-const spouts = documentSpout({ title: 'anansi' })(
-  restHooksSpout()(
-    routerSpout({
-      useResolveWith: useController,
-      createRouter,
-    })(appSpout),
+const spouts = JSONSpout()(
+  documentSpout({ title: 'anansi' })(
+    restHooksSpout()(
+      routerSpout({
+        useResolveWith: useController,
+        createRouter,
+      })(appSpout),
+    ),
   ),
 );
 

--- a/packages/core/src/index.server.ts
+++ b/packages/core/src/index.server.ts
@@ -3,3 +3,4 @@ export { default as documentSpout } from './spouts/document.server';
 export { default as restHooksSpout } from './spouts/restHooks.server';
 export { default as routerSpout } from './spouts/router.server';
 export { default as prefetchSpout } from './spouts/prefetch.server';
+export { default as JSONSpout } from './spouts/json.server';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export { default as floodSpouts } from './floodSpouts';
 export { default as documentSpout } from './spouts/document';
 export { default as restHooksSpout } from './spouts/restHooks';
 export { default as routerSpout } from './spouts/router';
+export { default as JSONSpout } from './spouts/json';

--- a/packages/core/src/laySpouts.tsx
+++ b/packages/core/src/laySpouts.tsx
@@ -1,4 +1,5 @@
 import { renderToPipeableStream as reactRender } from 'react-dom/server';
+import crypto from 'crypto';
 
 import { Render } from './scripts/types';
 import { ServerProps } from './spouts/types';
@@ -10,7 +11,9 @@ export default function laySpouts(
   { timeoutMS = 200 }: { timeoutMS?: number } = {},
 ) {
   const render: Render = async (clientManifest, req, res) => {
-    const { app } = await spouts({ clientManifest, req, res });
+    const nonce = crypto.randomBytes(16).toString('base64');
+
+    const { app } = await spouts({ clientManifest, req, res, nonce });
     let didError = false;
     const { pipe, abort } = reactRender(
       app,
@@ -31,6 +34,7 @@ type Options = {|
 |};
   */
       {
+        nonce,
         //bootstrapScripts: assets.filter(asset => asset.endsWith('.js')),
         onShellReady() {
           //managers.forEach(manager => manager.cleanup());

--- a/packages/core/src/spouts/csp.ts
+++ b/packages/core/src/spouts/csp.ts
@@ -1,0 +1,25 @@
+export interface Policy {
+  [directive: string]: string | string[];
+}
+
+// TODO: memoize this
+export function buildPolicy(policyObj: Policy) {
+  return Object.keys(policyObj)
+    .map(key => {
+      const val = Array.isArray(policyObj[key])
+        ? [...new Set(policyObj[key]).values()].filter(v => v).join(' ')
+        : policyObj[key];
+
+      // move strict dynamic to the end of the policy if it exists to be backwards compatible with csp2
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic
+      if (typeof val === 'string' && val.includes("'strict-dynamic'")) {
+        const newVal = `${val
+          .replace(/\s?'strict-dynamic'\s?/gi, ' ')
+          .trim()} 'strict-dynamic'`;
+        return `${key} ${newVal}`;
+      }
+
+      return `${key} ${val}`;
+    })
+    .join('; ');
+}

--- a/packages/core/src/spouts/document.server.tsx
+++ b/packages/core/src/spouts/document.server.tsx
@@ -3,11 +3,13 @@ import type { Route } from '@anansi/router';
 import { StatsChunkGroup } from 'webpack';
 
 import type { ServerProps, ResolveProps } from './types';
+import type { Policy } from './csp';
 import Document from './DocumentComponent';
 
 type NeededProps = {
   matchedRoutes: Route<any>[];
   title?: string;
+  scripts?: React.ReactNode[];
 } & ResolveProps;
 
 export default function DocumentSpout(options: {
@@ -15,6 +17,7 @@ export default function DocumentSpout(options: {
   title: string;
   rootId?: string;
   charSet?: string;
+  csPolicy?: Policy;
 }) {
   return function <T extends NeededProps>(
     next: (props: ServerProps) => Promise<T>,
@@ -78,6 +81,9 @@ export default function DocumentSpout(options: {
             title={nextProps.title ?? options.title}
             assets={assets}
             rootId={options.rootId}
+            nonce={props.nonce}
+            csPolicy={options.csPolicy}
+            scripts={nextProps.scripts}
           >
             {nextProps.app}
           </Document>

--- a/packages/core/src/spouts/document.tsx
+++ b/packages/core/src/spouts/document.tsx
@@ -12,9 +12,11 @@ export default function documentSpout(options: {
   head?: React.ReactNode;
   title: string;
 }) {
-  return function <T extends NeededProps>(next: () => Promise<T>) {
-    return async () => {
-      const nextProps = await next();
+  return function <T extends NeededProps>(
+    next: (initData: Record<string, unknown>) => Promise<T>,
+  ) {
+    return async (initData: Record<string, unknown>) => {
+      const nextProps = await next(initData);
 
       return nextProps;
     };

--- a/packages/core/src/spouts/json.server.tsx
+++ b/packages/core/src/spouts/json.server.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import type { Route } from '@anansi/router';
+import { StatsChunkGroup } from 'webpack';
+
+import type { ServerProps, ResolveProps } from './types';
+import type { Policy } from './csp';
+import Document from './DocumentComponent';
+
+type NeededProps = {
+  initData?: Record<string, () => unknown>;
+  scripts?: React.ReactNode[];
+} & ResolveProps;
+
+export default function JSONSpout({
+  id = 'anansi-json',
+}: { id?: string } = {}) {
+  return function <T extends NeededProps>(
+    next: (props: ServerProps) => Promise<T>,
+  ) {
+    return async (props: ServerProps) => {
+      const nextProps = await next(props);
+
+      const scripts: React.ReactNode[] = nextProps.scripts ?? [];
+      /*
+      Object.entries(nextProps.initData ?? {}).forEach(([key, data]) => {
+        try {
+          const encoded = JSON.stringify(data);
+          scripts.push(
+            <script
+              key={key}
+              id={`${id}-${key}`}
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html: encoded,
+              }}
+              nonce={props.nonce}
+            />,
+          );
+        } catch (e) {
+          // TODO: Use unified logging
+          console.error(e);
+        }
+      });*/
+      const Script = () => {
+        try {
+          const data: any = {};
+          Object.entries(nextProps.initData ?? {}).forEach(([key, getData]) => {
+            data[key] = getData();
+          });
+          const encoded = JSON.stringify(data);
+          return (
+            <script
+              key={id}
+              id={id}
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html: encoded,
+              }}
+              nonce={props.nonce}
+            />
+          );
+        } catch (e) {
+          // TODO: Use unified logging
+          console.error('Error serializing json');
+          console.error(e);
+          return null;
+        }
+      };
+      scripts.push(<Script />);
+
+      return {
+        ...nextProps,
+        scripts,
+      };
+    };
+  };
+}

--- a/packages/core/src/spouts/json.tsx
+++ b/packages/core/src/spouts/json.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { Route } from '@anansi/router';
+
+import type { ResolveProps } from './types';
+
+type NeededProps = ResolveProps;
+
+export default function JSONSpout({
+  id = 'anansi-json',
+}: { id?: string } = {}) {
+  return function <T extends NeededProps>(
+    next: (initData: Record<string, unknown>) => Promise<T>,
+  ) {
+    return async () => {
+      const initData = getDatafromDOM(id);
+      const nextProps = await next(initData);
+
+      return nextProps;
+    };
+  };
+}
+function getDatafromDOM(id: string): Record<string, unknown> {
+  const element = document.querySelector(`#${id}`);
+  return element?.innerHTML ? JSON.parse(element?.innerHTML) : undefined;
+}

--- a/packages/core/src/spouts/restHooks.server.tsx
+++ b/packages/core/src/spouts/restHooks.server.tsx
@@ -1,9 +1,9 @@
 import { Manager, NetworkManager } from '@rest-hooks/core';
-import { createPersistedStore } from '@rest-hooks/ssr';
 
+import { createPersistedStore } from './rhHelp';
 import type { ResolveProps, ServerProps } from './types';
 
-type NeededProps = ResolveProps;
+type NeededProps = { initData?: Record<string, () => unknown> } & ResolveProps;
 
 export default function restHooksSpout(
   options: {
@@ -14,7 +14,7 @@ export default function restHooksSpout(
     next: (props: ServerProps) => Promise<T>,
   ) {
     return async (props: ServerProps) => {
-      const [ServerCacheProvider, controller] = createPersistedStore(
+      const [ServerCacheProvider, controller, store] = createPersistedStore(
         options.getManagers(),
       );
 
@@ -23,6 +23,10 @@ export default function restHooksSpout(
       return {
         ...nextProps,
         controller,
+        initData: {
+          ...nextProps.initData,
+          resthooks: () => store.getState(),
+        },
         app: <ServerCacheProvider>{nextProps.app}</ServerCacheProvider>,
       };
     };

--- a/packages/core/src/spouts/restHooks.tsx
+++ b/packages/core/src/spouts/restHooks.tsx
@@ -1,5 +1,9 @@
-import { CacheProvider, Manager, NetworkManager } from '@rest-hooks/core';
-import { ServerDataComponent, getDatafromDOM } from '@rest-hooks/ssr';
+import {
+  CacheProvider,
+  Manager,
+  NetworkManager,
+  State,
+} from '@rest-hooks/core';
 
 import type { ResolveProps } from './types';
 
@@ -10,18 +14,19 @@ export default function restHooksSpout(
     getManagers: () => Manager[];
   } = { getManagers: () => [new NetworkManager()] },
 ) {
-  return function <T extends NeededProps>(next: () => Promise<T>) {
-    return async () => {
-      const data = getDatafromDOM();
+  return function <T extends NeededProps>(
+    next: (initData: Record<string, unknown>) => Promise<T>,
+  ) {
+    return async (initData: Record<string, unknown>) => {
+      const data = initData.resthooks as State<unknown>;
 
-      const nextProps = await next();
+      const nextProps = await next(initData);
 
       return {
         ...nextProps,
         app: (
           <CacheProvider initialState={data} managers={options.getManagers()}>
             {nextProps.app}
-            <ServerDataComponent data={data} />
           </CacheProvider>
         ),
       };

--- a/packages/core/src/spouts/rhHelp.tsx
+++ b/packages/core/src/spouts/rhHelp.tsx
@@ -1,0 +1,37 @@
+import { ExternalCacheProvider, PromiseifyMiddleware } from 'rest-hooks';
+import {
+  Controller,
+  createReducer,
+  initialState,
+  Manager,
+  applyManager,
+  NetworkManager,
+} from '@rest-hooks/core';
+import { createStore, applyMiddleware } from 'redux';
+
+// TODO: Rework this and upstream to rest hooks
+export function createPersistedStore(managers?: Manager[]) {
+  const controller = new Controller();
+  managers = managers ?? [new NetworkManager()];
+  const reducer = createReducer(controller);
+  const enhancer = applyMiddleware(
+    ...applyManager(managers, controller),
+    PromiseifyMiddleware as any,
+  );
+  const store = createStore(reducer, initialState as any, enhancer);
+  managers.forEach(manager => manager.init?.(store.getState()));
+
+  const selector = (state: any) => state;
+  function ServerCacheProvider({ children }: { children: React.ReactNode }) {
+    return (
+      <ExternalCacheProvider
+        store={store}
+        selector={selector}
+        controller={controller}
+      >
+        {children}
+      </ExternalCacheProvider>
+    );
+  }
+  return [ServerCacheProvider, controller, store] as const;
+}

--- a/packages/core/src/spouts/router.tsx
+++ b/packages/core/src/spouts/router.tsx
@@ -30,13 +30,15 @@ export default function routerSpout<ResolveWith>(options: {
       );
     };
 
-  return function <T extends NeededProps>(next: () => Promise<T>) {
-    return async () => {
+  return function <T extends NeededProps>(
+    next: (initData: Record<string, unknown>) => Promise<T>,
+  ) {
+    return async (initData: Record<string, unknown>) => {
       const history = createBrowserHistory();
       const router = options.createRouter(history);
       const matchedRoutes = router.getMatchedRoutes(history.location.pathname);
 
-      const nextProps = await next();
+      const nextProps = await next(initData);
 
       const Router = createRouteComponent(router);
       return {

--- a/packages/core/src/spouts/types.ts
+++ b/packages/core/src/spouts/types.ts
@@ -9,6 +9,7 @@ export type ServerProps = {
   req: Request | IncomingMessage;
   res: Response | ServerResponse;
   clientManifest: StatsCompilation;
+  nonce: string;
 };
 
 /* Baseline expectations of return value */

--- a/packages/generator-js/src/ssr/templates/src/index.server.tsx
+++ b/packages/generator-js/src/ssr/templates/src/index.server.tsx
@@ -19,8 +19,21 @@ const app = (
 
 const appSpout = () => Promise.resolve({ app });
 
+const csPolicy = {
+  'base-uri': "'self'",
+  'object-src': "'none'",
+  'script-src': ["'self'"],
+  'style-src': ["'unsafe-inline'", "'self'"],
+};
+if (process.env.NODE_ENV !== 'production') {
+  csPolicy['script-src'].push("'unsafe-inline");
+}
+
 const spouts = prefetchSpout('controller')(
-  documentSpout({ title: 'anansi' })(
+  documentSpout({
+    title: 'anansi',
+    csPolicy,
+  })(
     restHooksSpout()(
       routerSpout({ useResolveWith: useController, createRouter })(appSpout),
     ),


### PR DESCRIPTION
## Client spouts

- JSON spout adds initData to each

```ts
const spouts = JSONSpout()(
  documentSpout({ title: 'anansi' })(
    restHooksSpout()(
      routerSpout({
        useResolveWith: useController,
        createRouter,
      })(appSpout),
    ),
  ),
);

export default floodSpouts(spouts);
```

## Server spouts

- nonce is added to init props (with manifest req,res, etc)
- initData return value is used by JSON spout to embed to be loaded. takes functions to run at final stage

```ts
{
    initData: {
      ...nextProps.initData,
      resthooks: () => store.getState(),
    },
}
```

```ts
const spouts = prefetchSpout('controller')(
  documentSpout({
    title: 'anansi',
  })(
    JSONSpout()(
      restHooksSpout()(
        routerSpout({ useResolveWith: useController, createRouter })(appSpout),
      ),
    ),
  ),
);

export default laySpouts(spouts);
```