### PR TITLE
fix: Provide rest-hooks package for rest-hooks/ssr

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,6 +104,7 @@
     "@types/react-dom": "^17.0.40 || ^18.0.0-0",
     "react": "^18.0.0-0",
     "react-dom": "^18.0.0-0",
+    "rest-hooks": "^6.0.0",
     "webpack": "^5.60.0"
   },
   "peerDependenciesMeta": {
@@ -114,6 +115,9 @@
       "optional": true
     },
     "@types/react-dom": {
+      "optional": true
+    },
+    "rest-hooks": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,7 @@ __metadata:
     "@types/react-dom": ^17.0.40 || ^18.0.0-0
     react: ^18.0.0-0
     react-dom: ^18.0.0-0
+    rest-hooks: ^6.0.0
     webpack: ^5.60.0
   peerDependenciesMeta:
     "@rest-hooks/core":
@@ -166,6 +167,8 @@ __metadata:
     "@types/react":
       optional: true
     "@types/react-dom":
+      optional: true
+    rest-hooks:
       optional: true
   bin:
     serve-anansi: ./lib/scripts/serve.js


### PR DESCRIPTION
`@anansi/core@npm:0.14.0 [a8f24] doesn't provide rest-hooks (p7e75d), requested by @rest-hooks/ssr`