### PR TITLE
fix: Spout type removes provided props from needed props

### DIFF
--- a/examples/concurrent/.eslintrc.js
+++ b/examples/concurrent/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      typescript: {project: path.resolve(__dirname, './tsconfig.json')},
+      typescript: { project: path.resolve(__dirname, './tsconfig.json') },
     },
   },
 };

--- a/examples/concurrent/src/index.server.tsx
+++ b/examples/concurrent/src/index.server.tsx
@@ -6,11 +6,8 @@ import {
   prefetchSpout,
   routerSpout,
   JSONSpout,
-  ServerProps,
-  //appSpout,
-  Spout,
+  appSpout,
 } from '@anansi/core/server';
-import { Controller } from '@rest-hooks/core';
 
 import app from 'app';
 
@@ -26,21 +23,6 @@ if (process.env.NODE_ENV !== 'production') {
   csPolicy['script-src'].push("'unsafe-inline'");
 }
 
-const appSpout =
-  (app: JSX.Element) =>
-  (props: ServerProps): Promise<{ app: JSX.Element }> =>
-    Promise.resolve({ ...props, app });
-
-const authSpout: Spout<{ controller: Controller }, unknown, unknown> =
-  next => async props => {
-    const nextProps = await next(props);
-
-    return nextProps;
-  };
-const ap = appSpout(app);
-const r = routerSpout({ useResolveWith: useController, createRouter })(ap);
-const a = authSpout(r);
-const b = restHooksSpout()(a);
 const spouts = prefetchSpout('controller')(
   documentSpout({
     title: 'anansi',
@@ -48,10 +30,8 @@ const spouts = prefetchSpout('controller')(
   })(
     JSONSpout()(
       restHooksSpout()(
-        authSpout(
-          routerSpout({ useResolveWith: useController, createRouter })(
-            appSpout(app),
-          ),
+        routerSpout({ useResolveWith: useController, createRouter })(
+          appSpout(app),
         ),
       ),
     ),
@@ -59,5 +39,3 @@ const spouts = prefetchSpout('controller')(
 );
 
 export default laySpouts(spouts);
-
-type A = unknown & ServerProps;

--- a/examples/typescript/.eslintrc.js
+++ b/examples/typescript/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      typescript: {project: path.resolve(__dirname, './tsconfig.json')},
+      typescript: { project: path.resolve(__dirname, './tsconfig.json') },
     },
   },
 };

--- a/packages/core/src/spouts/restHooks.server.tsx
+++ b/packages/core/src/spouts/restHooks.server.tsx
@@ -10,7 +10,7 @@ export default function restHooksSpout(
   } = { getManagers: () => [new NetworkManager()] },
 ): ServerSpout<
   Record<string, unknown>,
-  { controller: Controller; store: Store<State<unknown>> },
+  { controller: Controller } & { store: Store<State<unknown>> },
   { initData?: Record<string, () => unknown> }
 > {
   return next => async props => {

--- a/packages/core/src/spouts/router.server.tsx
+++ b/packages/core/src/spouts/router.server.tsx
@@ -12,9 +12,9 @@ export default function routerSpout<ResolveWith>(options: {
   Record<string, unknown>,
   {
     matchedRoutes: Route<ResolveWith>[];
+  } & {
     router: RouteController<Route<ResolveWith, any>>;
-  },
-  Record<string, unknown>
+  }
 > {
   const createRouteComponent = (
     router: RouteController<Route<ResolveWith, any>>,

--- a/packages/core/src/spouts/router.server.tsx
+++ b/packages/core/src/spouts/router.server.tsx
@@ -13,7 +13,8 @@ export default function routerSpout<ResolveWith>(options: {
   {
     matchedRoutes: Route<ResolveWith>[];
     router: RouteController<Route<ResolveWith, any>>;
-  }
+  },
+  Record<string, unknown>
 > {
   const createRouteComponent = (
     router: RouteController<Route<ResolveWith, any>>,

--- a/packages/core/src/spouts/router.tsx
+++ b/packages/core/src/spouts/router.tsx
@@ -14,6 +14,7 @@ export default function routerSpout<ResolveWith>(options: {
   Record<string, unknown>,
   {
     matchedRoutes: Route<ResolveWith, any>[];
+  } & {
     router: RouteController<Route<ResolveWith, any>>;
   }
 > {

--- a/packages/core/src/spouts/types.ts
+++ b/packages/core/src/spouts/types.ts
@@ -22,19 +22,26 @@ export type CreateRouter<T> = (
 ) => RouteController<Route<T, any>>;
 
 /* Spouts are middleware for Anansi */
-export type ServerSpout<
-  NeededProps extends Record<string, unknown> = Record<string, unknown>,
-  ProvidedProps extends Record<string, unknown> = Record<string, unknown>,
-  NeededNext extends Record<string, unknown> = NeededProps,
-> = <N extends NeededNext & ResolveProps, I extends NeededProps & ServerProps>(
-  next: (props: I & ProvidedProps) => Promise<N>,
-) => (props: I) => Promise<N & ProvidedProps>;
+export declare type ServerSpout<
+  NeededProps = unknown,
+  ProvidedProps = unknown,
+  NeededNext = unknown,
+> = <
+  N extends NeededNext & ResolveProps,
+  I extends ServerProps & ProvidedProps,
+>(
+  next: (props: I) => Promise<N>,
+) => (
+  props: NeededProps & Omit<I, keyof ProvidedProps>,
+) => Promise<N & ProvidedProps>;
 
 /* Spouts are middleware for Anansi */
-export type ClientSpout<
-  NeededProps extends Record<string, unknown> = Record<string, unknown>,
-  ProvidedProps extends Record<string, unknown> = Record<string, unknown>,
-  NeededNext extends Record<string, unknown> = NeededProps,
-> = <N extends NeededNext & ResolveProps, I extends NeededProps>(
-  next: (props: I & ProvidedProps) => Promise<N>,
-) => (props: I) => Promise<N & ProvidedProps>;
+export declare type ClientSpout<
+  NeededProps = unknown,
+  ProvidedProps = unknown,
+  NeededNext = unknown,
+> = <N extends NeededNext & ResolveProps, I extends ProvidedProps>(
+  next: (props: I) => Promise<N>,
+) => (
+  props: NeededProps & Omit<I, keyof ProvidedProps>,
+) => Promise<N & ProvidedProps>;

--- a/packages/core/src/spouts/types.ts
+++ b/packages/core/src/spouts/types.ts
@@ -22,26 +22,19 @@ export type CreateRouter<T> = (
 ) => RouteController<Route<T, any>>;
 
 /* Spouts are middleware for Anansi */
-export declare type ServerSpout<
-  NeededProps = unknown,
-  ProvidedProps = unknown,
-  NeededNext = unknown,
-> = <
-  N extends NeededNext & ResolveProps,
-  I extends ServerProps & ProvidedProps,
->(
-  next: (props: I) => Promise<N>,
-) => (
-  props: NeededProps & Omit<I, keyof ProvidedProps>,
-) => Promise<N & ProvidedProps>;
+export type ServerSpout<
+  NeededProps extends Record<string, unknown> = Record<string, unknown>,
+  ProvidedProps extends Record<string, unknown> = Record<string, unknown>,
+  NeededNext extends Record<string, unknown> = Record<string, unknown>,
+> = <N extends NeededNext & ResolveProps, I extends ServerProps>(
+  next: (props: I & ProvidedProps) => Promise<N>,
+) => (props: NeededProps & I) => Promise<N & ProvidedProps>;
 
 /* Spouts are middleware for Anansi */
-export declare type ClientSpout<
-  NeededProps = unknown,
-  ProvidedProps = unknown,
-  NeededNext = unknown,
-> = <N extends NeededNext & ResolveProps, I extends ProvidedProps>(
-  next: (props: I) => Promise<N>,
-) => (
-  props: NeededProps & Omit<I, keyof ProvidedProps>,
-) => Promise<N & ProvidedProps>;
+export type ClientSpout<
+  NeededProps extends Record<string, unknown> = Record<string, unknown>,
+  ProvidedProps extends Record<string, unknown> = Record<string, unknown>,
+  NeededNext extends Record<string, unknown> = Record<string, unknown>,
+> = <N extends NeededNext & ResolveProps, I>(
+  next: (props: I & ProvidedProps) => Promise<N>,
+) => (props: NeededProps & I) => Promise<N & ProvidedProps>;


### PR DESCRIPTION
When a Spout provides a prop it should no longer need that prop. We must separate each provided prop into its own intersection for TypeScript to correctly infer this. Unfortunately this does require a somewhat non intuitive crafting for Spout authors but it's the best we can do for now.