### PR TITLE
internal: Don't repeat work in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: yarn workspaces foreach run build:storybook
+      - run: yarn workspace example-typescript build:storybook
 
 
 workflows:

--- a/examples/concurrent/package.json
+++ b/examples/concurrent/package.json
@@ -12,6 +12,7 @@
     "build:profile": "webpack --mode=production --env profile",
     "pkgcheck": "webpack --env check=nobuild",
     "test:type": "tsc --noEmit",
+    "test:ci": "echo hi",
     "postinstall": "rm -rf node_modules/.cache"
   },
   "devDependencies": {


### PR DESCRIPTION
If there is only one workspace with a script, it will be run from any location - thus foreach runs that same script X times where X is the number of workspaces.

For test - just add another one as we anticipate having more test suites. For storybook we will call the specific workspace directly as we don't expect to add storybook to any other workspace.