### PR TITLE
enhance: Enable terser parallelism in WSL

### DIFF
--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -6,7 +6,6 @@ import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import RemoveEmptyScriptsPlugin from 'webpack-remove-empty-scripts';
 import PreloadWebpackPlugin from '@vue/preload-webpack-plugin';
-import isWsl from 'is-wsl';
 
 import { getStyleRules } from './base';
 
@@ -143,9 +142,6 @@ export default function makeProdConfig(
           keep_fnames: !!env?.profile || terserOptions?.keep_fnames,
         },
         extractComments: true,
-        // Disabled on WSL (Windows Subsystem for Linux) due to an issue with Terser
-        // https://github.com/webpack-contrib/terser-webpack-plugin/issues/21
-        parallel: !isWsl,
       }),
       // cssnano on node_modules as well as our loaders
       new CssMinimizerPlugin(),


### PR DESCRIPTION
https://github.com/webpack-contrib/terser-webpack-plugin/issues/21 has long been fixed so disabling is not necessary.

Now 6s full production build:

```bash
assets by path *.js 704 KiB
  assets by chunk 264 KiB (id hint: vendors)
    asset 690-0d86d44ea3431adc.chunk.js 90 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 224-978f26359dba3628.chunk.js 55.3 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 126-13d3e8ed527e1961.chunk.js 39.9 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 163-3d0dd12cf508907f.chunk.js 33.7 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 65-951551524311aa7d.chunk.js 19.6 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 160-30ce08321aea8374.chunk.js 17.8 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
    asset 267-e8a493d62ead3f6b.chunk.js 7.55 KiB [emitted] [immutable] [minimized] (id hint: vendors) 1 related asset
  + 14 assets
assets by path *.css 533 KiB
  asset App.f0d504709ef8e717.css 532 KiB [emitted] [immutable] [minimized] [big] (name: App) 1 related asset
  asset PostDetail.89d86759639da0fb.css 166 bytes [emitted] [immutable] [minimized] (name: PostDetail) 1 related asset
asset manifest.json 115 KiB [emitted]
asset index.html 516 bytes [emitted]
Entrypoint App [big] 961 KiB (3.29 MiB) = webpack-runtime-09dac7328ea316b3.js 5.04 KiB polyfill-b2642ed2f41ed961.js 13.8 KiB react-1ae4f2c329035f00.js 138 KiB App.f0d504709ef8e717.css 532 KiB App-3d9bded10dfde490.js 271 KiB 5 auxiliary assets
orphan modules 6.79 MiB (javascript) 3.7 KiB (runtime) [orphan] 2605 modules
runtime modules 11.9 KiB 17 modules
built modules 1.93 MiB (javascript) 654 KiB (css/mini-extract) [built]
  modules by path ../../node_modules/ 1.74 MiB (javascript) 654 KiB (css/mini-extract) 170 modules
  modules by path ./src/ 182 KiB (javascript) 615 bytes (css/mini-extract)
    javascript modules 182 KiB 20 modules
    css modules 615 bytes
      css ../../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].oneOf[1].use[1]!../../node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].oneOf[1].use[2]!../../node_modules/@linaria/webpack5-loader/lib/outputCssLoader.js?cacheProvider=!./src/app/App.tsx 101 bytes [built] [code generated]
      + 2 modules
  modules by path ../../packages/ 11.5 KiB
    modules by path ../../packages/core/lib/ 3.81 KiB 7 modules
    modules by path ../../packages/router/src/ 4.68 KiB 6 modules
    modules by path ../../packages/pojo-router/src/ 3 KiB
      modules by path ../../packages/pojo-router/src/*.ts 1.77 KiB 2 modules
      modules by path ../../packages/pojo-router/src/*.tsx 1.23 KiB 2 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  App.f0d504709ef8e717.css (532 KiB)
  App-3d9bded10dfde490.js (271 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (293 KiB). This can impact web performance.
Entrypoints:
  App (961 KiB)
      webpack-runtime-09dac7328ea316b3.js
      polyfill-b2642ed2f41ed961.js
      react-1ae4f2c329035f00.js
      App.f0d504709ef8e717.css
      App-3d9bded10dfde490.js


webpack 5.74.0 compiled with 2 warnings in 6663 ms
```