### PR TITLE
fix: Production builds work in node 18

### DIFF
--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -217,7 +217,10 @@ export default function makeBaseConfig({
                 {
                   loader: require.resolve('file-loader'),
                   options: {
-                    name: assetModuleFilename,
+                    name:
+                      nohash || mode !== 'production'
+                        ? '[name].[ext][query]'
+                        : '[md5:contenthash:base64:8].[ext][query]',
                   },
                 },
               ],

--- a/packages/webpack-config-anansi/src/base/linariaFileCache.js
+++ b/packages/webpack-config-anansi/src/base/linariaFileCache.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const mkdirp = require('mkdirp');
 
 const hashFileName = name => {
-  const hash = crypto.createHash('md4');
+  const hash = crypto.createHash('md5');
   hash.update(name);
   return hash.digest('hex');
 };

--- a/packages/webpack-config-anansi/src/dev.js
+++ b/packages/webpack-config-anansi/src/dev.js
@@ -154,7 +154,7 @@ export default function makeDevConfig(
     libraryInclude,
     libraryExclude,
     cssModulesOptions: {
-      localIdentName: '[folder]_[name]__[local]___[hash:base64:5]',
+      localIdentName: '[folder]_[name]__[local]___[xxhash64:hash:base64:5]',
       ...cssModulesOptions,
     },
     sassOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16798,13 +16798,13 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "loader-utils@npm:2.0.0"
+  version: 2.0.2
+  resolution: "loader-utils@npm:2.0.2"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^2.1.2
-  checksum: 6856423131b50b6f5f259da36f498cfd7fc3c3f8bb17777cf87fdd9159e797d4ba4288d9a96415fd8da62c2906960e88f74711dee72d03a9003bddcd0d364a51
+  checksum: 9078d1ed47cadc57f4c6ddbdb2add324ee7da544cea41de3b7f1128e8108fcd41cd3443a85b7ee8d7d8ac439148aa221922774efe4cf87506d4fb054d5889303
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We're forced to use loaders to have dual imports (https://react-svgr.com/docs/webpack/#use-with-url-loader-or-file-loader). However, the last file-loader uses outdated loader-utils so it does not support the new hashing method.

Use md5 instead of md4 (when xxhash64 is not supported) as that is still supported in node 18.