### PR TITLE
feat: Add option to disable CSS extraction

### DIFF
--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -483,6 +483,11 @@ linaria has its own config files it can use, and it is recommended to use those 
 
 [Configuring Linaria](https://github.com/callstack/linaria/blob/master/docs/CONFIGURATION.md#options)
 
+### cssExtractOptions
+
+Can configure how [MiniCssExtractPlugin](https://github.com/webpack-contrib/mini-css-extract-plugin) operates.  Set to `false` to disable CSS extraction altogether.
+
+[Configuration options](https://github.com/webpack-contrib/mini-css-extract-plugin#options)
 ### tsconfigPathOptions
 
 Enabled by default. Uses any module resolution specifications like aliases in `tsconfig`.

--- a/packages/webpack-config-anansi/README.md
+++ b/packages/webpack-config-anansi/README.md
@@ -488,6 +488,7 @@ linaria has its own config files it can use, and it is recommended to use those 
 Can configure how [MiniCssExtractPlugin](https://github.com/webpack-contrib/mini-css-extract-plugin) operates.  Set to `false` to disable CSS extraction altogether.
 
 [Configuration options](https://github.com/webpack-contrib/mini-css-extract-plugin#options)
+
 ### tsconfigPathOptions
 
 Enabled by default. Uses any module resolution specifications like aliases in `tsconfig`.

--- a/packages/webpack-config-anansi/index.d.ts
+++ b/packages/webpack-config-anansi/index.d.ts
@@ -10,6 +10,7 @@ import type { Options as TsconfigPathsOptions } from 'tsconfig-paths-webpack-plu
 import type { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import type { TransformOptions } from '@babel/core';
 import type { Options as SassOptions } from 'sass-loader';
+import { PluginOptions as MiniCssExtractPluginOptions } from 'mini-css-extract-plugin';
 
 export interface Options {
   rootPath?: string;
@@ -28,6 +29,7 @@ export interface Options {
   svgoOptions?: OptimizeOptions | false;
   svgrOptions?: any | false;
   linariaOptions?: PluginOptions | false;
+  cssExtractOptions?: MiniCssExtractPluginOptions | false;
   tsconfigPathsOptions?: TsconfigPathsOptions | false;
   globalStyleDir?: string | false;
   sassOptions?: SassOptions | false;

--- a/packages/webpack-config-anansi/src/base/css.js
+++ b/packages/webpack-config-anansi/src/base/css.js
@@ -4,12 +4,13 @@ import path from 'path';
 import cssPresetEnv from 'postcss-preset-env';
 import { always } from 'ramda';
 
-const getCSSLoaders = ({ mode, target }) => {
+const getCSSLoaders = ({ mode, target, cssExtractOptions }) => {
+  const miniCssExtractPluginLoader = {
+    loader: MiniCssExtractPlugin.loader,
+    options: { emit: !target?.includes?.('node') },
+  };
+
   const loaders = [
-    {
-      loader: MiniCssExtractPlugin.loader,
-      options: { emit: !target?.includes?.('node') },
-    },
     {
       loader: require.resolve('css-loader'),
       options:
@@ -37,7 +38,10 @@ const getCSSLoaders = ({ mode, target }) => {
       },
     },
   ];
-  return loaders;
+
+  return cssExtractOptions === false
+    ? loaders
+    : [miniCssExtractPluginLoader, ...loaders];
 };
 
 const getSASSLoaders = ({ sassResources, sassOptions }) => {
@@ -69,9 +73,10 @@ export default function getStyleRules({
   globalStyleDir,
   mode,
   target,
+  cssExtractOptions,
 }) {
   const absoluteBasePath = path.join(rootPath, basePath);
-  const cssLoaders = getCSSLoaders({ mode, target });
+  const cssLoaders = getCSSLoaders({ mode, target, cssExtractOptions });
   const cssModuleLoaders = cssLoaders.map(loader => {
     if (/($|\/)css-loader/.test(loader.loader)) {
       return {

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -31,6 +31,7 @@ export default function makeBaseConfig({
   nohash,
   argv,
   env,
+  cssExtractOptions,
 }) {
   const WEBPACK_PUBLIC_HOST = process.env.WEBPACK_PUBLIC_HOST || '';
   const WEBPACK_PUBLIC_PATH = process.env.WEBPACK_PUBLIC_PATH || '/';
@@ -89,6 +90,33 @@ export default function makeBaseConfig({
     ];
   }
 
+  const plugins = [
+    new StatsWriterPlugin({
+      filename: manifestFilename,
+      stats: {
+        chunkModules: false,
+        source: false,
+        chunks: false,
+        modules: false,
+        assets: true,
+      },
+    }),
+  ]
+
+  if(cssExtractOptions !== false) {
+    plugins.push(new MiniCssExtractPlugin({
+      filename:
+        (mode !== 'production') | nohash
+          ? '[name].css'
+          : '[name].[contenthash].css',
+      chunkFilename:
+        (mode !== 'production') | nohash
+          ? '[name].css'
+          : '[name].[contenthash].css',
+      ...cssExtractOptions,
+    }))
+  }
+
   const assetModuleFilename =
     nohash || mode !== 'production'
       ? '[name].[ext][query]'
@@ -126,28 +154,7 @@ export default function makeBaseConfig({
         env: [process.env.NODE_ENV, process.env.BROWSERSLIST_ENV].join(','),
       }),
     },
-    plugins: [
-      new StatsWriterPlugin({
-        filename: manifestFilename,
-        stats: {
-          chunkModules: false,
-          source: false,
-          chunks: false,
-          modules: false,
-          assets: true,
-        },
-      }),
-      new MiniCssExtractPlugin({
-        filename:
-          (mode !== 'production') | nohash
-            ? '[name].css'
-            : '[name].[contenthash].css',
-        chunkFilename:
-          (mode !== 'production') | nohash
-            ? '[name].css'
-            : '[name].[contenthash].css',
-      }),
-    ],
+    plugins: plugins,
     module: {
       rules: [
         {

--- a/packages/webpack-config-anansi/src/dev.js
+++ b/packages/webpack-config-anansi/src/dev.js
@@ -25,6 +25,7 @@ export default function makeDevConfig(
     cssModulesOptions,
     globalStyleDir,
     isStackblitz,
+    cssExtractOptions,
   },
 ) {
   const config = { ...baseConfig };
@@ -161,6 +162,7 @@ export default function makeDevConfig(
     sassResources,
     globalStyleDir,
     target: argv?.target,
+    cssExtractOptions,
   });
   config.module.rules = [...config.module.rules, styleRules];
   return config;

--- a/packages/webpack-config-anansi/src/index.js
+++ b/packages/webpack-config-anansi/src/index.js
@@ -27,7 +27,6 @@ export function makeConfig(options) {
       serverDir: 'server_assets/',
       manifestFilename: 'manifest.json',
       extraJsLoaders: [],
-      cssExtractOptions: {},
       ...options,
       mode: argv?.mode || process.env.NODE_ENV,
       nohash:
@@ -66,6 +65,11 @@ export function makeConfig(options) {
     if ('linariaOptions' in options && options.linariaOptions === undefined) {
       throw new Error(
         'Undefined is not a valid option for linariaOptions. To disable use `false`',
+      );
+    }
+    if ('cssExtractOptions' in options && options.cssExtractOptions === undefined) {
+      throw new Error(
+        'Undefined is not a valid option for cssExtractOptions. To disable use `false`',
       );
     }
     if (

--- a/packages/webpack-config-anansi/src/index.js
+++ b/packages/webpack-config-anansi/src/index.js
@@ -27,6 +27,7 @@ export function makeConfig(options) {
       serverDir: 'server_assets/',
       manifestFilename: 'manifest.json',
       extraJsLoaders: [],
+      cssExtractOptions: {},
       ...options,
       mode: argv?.mode || process.env.NODE_ENV,
       nohash:

--- a/packages/webpack-config-anansi/src/nobuild.js
+++ b/packages/webpack-config-anansi/src/nobuild.js
@@ -2,7 +2,7 @@ import { getStyleRules } from './base';
 
 export default function makeNobuildConfig(
   baseConfig,
-  { rootPath, basePath, cssModulesOptions, globalStyleDir, sassOptions },
+  { rootPath, basePath, cssModulesOptions, globalStyleDir, sassOptions, cssExtractOptions },
 ) {
   const config = { ...baseConfig };
   config.output = {
@@ -23,6 +23,7 @@ export default function makeNobuildConfig(
     cssModulesOptions,
     sassOptions,
     globalStyleDir,
+    cssExtractOptions,
   });
   config.module.rules = [...config.module.rules, styleRules];
   return config;

--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -27,6 +27,7 @@ export default function makeProdConfig(
     fontPreload,
     svgoOptions,
     nohash,
+    cssExtractOptions,
   },
 ) {
   const config = { ...baseConfig };
@@ -166,6 +167,7 @@ export default function makeProdConfig(
     cssModulesOptions,
     globalStyleDir,
     target: argv?.target,
+    cssExtractOptions,
   });
   config.module.rules = [...config.module.rules, styleRules];
 


### PR DESCRIPTION
For JS extensions, CSS can be difficult, so this adds an option to disable or control CSS extraction from the webpack config.  By default, no changes are made to the output, but this allows the ability to disable the extraction plugin or set any of its options.