### PR TITLE
fix: Compatibility with ESM exports packages

### DIFF
--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -45,9 +45,9 @@ export default function makeBaseConfig({
     // TODO: remove '.js', '.json', '.wasm' once '...' is well supported in plugins like linaria
     extensions: ['.ts', '.tsx', '.mts', '.cts', '.js', '.json', '.wasm', '...'],
     extensionAlias: {
-      '.js': ['.ts', '.tsx', '.js', '.jsx'],
-      '.mjs': ['.mts', '.mjs'],
-      '.cjs': ['.cts', '.cjs'],
+      '.js': ['.js', '.ts', '.tsx', '.jsx'],
+      '.mjs': ['.mjs', '.mts'],
+      '.cjs': ['.cjs', '.cts'],
     },
     fallback: NODE_ALIAS,
     plugins:


### PR DESCRIPTION
https://github.com/ntucker/anansi/commit/32bd97b7d3b2f9ff0697602a9747927a4fbf7ffc introduced [extensionAlias](https://webpack.js.org/configuration/resolve/#resolveextensionalias) usage to make importing a local .js file resolve .tsx. However, this also made it not work for ESM packages with exports members.

This is likely a bug as it should fallback. However, by making it look for .js first it seems to work for both cases.

References:
- https://github.com/vercel/next.js/pull/45423
- https://github.com/webpack/webpack/issues/13252