### PR TITLE
pkg: Upgrade linaria to 5

### DIFF
--- a/examples/concurrent/package.json
+++ b/examples/concurrent/package.json
@@ -65,9 +65,9 @@
     "@data-client/react": "0.9.6",
     "@data-client/redux": "0.9.4",
     "@data-client/rest": "0.9.5",
-    "@linaria/core": "4.2.10",
-    "@linaria/react": "4.3.8",
-    "@linaria/shaker": "4.2.11",
+    "@linaria/core": "5.0.0",
+    "@linaria/react": "5.0.0",
+    "@linaria/shaker": "5.0.0",
     "@types/node": "20.6.3",
     "antd": "5.9.2",
     "classnames": "2.3.2",
@@ -76,15 +76,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "redux": "^4.2.1"
-  },
-  "resolutions": {
-    "@linaria/babel-preset": "4.4.5",
-    "@linaria/core": "4.2.10",
-    "@linaria/webpack5-loader": "4.1.17",
-    "@linaria/react": "4.3.8",
-    "@linaria/shaker": "4.2.11",
-    "@linaria/utils": "4.3.4",
-    "@linaria/tags": "4.3.5"
   },
   "browserslist": [
     "extends @anansi/browserslist-config"

--- a/examples/linaria/package.json
+++ b/examples/linaria/package.json
@@ -50,23 +50,14 @@
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.22.15",
     "@babel/runtime": "7.22.15",
-    "@linaria/core": "4.2.10",
-    "@linaria/react": "4.3.8",
-    "@linaria/shaker": "4.2.11",
+    "@linaria/core": "5.0.0",
+    "@linaria/react": "5.0.0",
+    "@linaria/shaker": "5.0.0",
     "classnames": "2.3.2",
     "core-js": "3.32.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "redbox-react": "1.6.0"
-  },
-  "resolutions": {
-    "@linaria/babel-preset": "4.4.5",
-    "@linaria/core": "4.2.10",
-    "@linaria/webpack5-loader": "4.1.17",
-    "@linaria/react": "4.3.8",
-    "@linaria/shaker": "4.2.11",
-    "@linaria/utils": "4.3.4",
-    "@linaria/tags": "4.3.5"
   },
   "browserslist": [
     "extends @anansi/browserslist-config"

--- a/package.json
+++ b/package.json
@@ -74,14 +74,7 @@
     "webpack-dev-server": "4.15.1"
   },
   "resolutions": {
-    "normalize-url": "^6",
-    "@linaria/babel-preset": "4.4.5",
-    "@linaria/core": "4.2.10",
-    "@linaria/webpack5-loader": "4.1.17",
-    "@linaria/react": "4.3.8",
-    "@linaria/shaker": "4.2.11",
-    "@linaria/utils": "4.3.4",
-    "@linaria/tags": "4.3.5"
+    "normalize-url": "^6"
   },
   "dependencies": {
     "@lerna-lite/publish": "^2.0.0",

--- a/packages/babel-preset-anansi/index.js
+++ b/packages/babel-preset-anansi/index.js
@@ -25,6 +25,7 @@ function buildPreset(api, options = {}) {
   const babelNode = api.caller(
     caller => caller && caller.name === '@babel/node',
   );
+  const isLinaria = api.caller(caller => caller && caller.name === 'linaria');
   // babel cli will have no caller information, so in this case we should be aware and
   // possibly default to different options
   // (no caller info: https://github.com/babel/babel/issues/8930)
@@ -68,6 +69,7 @@ function buildPreset(api, options = {}) {
   const shouldHotReload =
     !babelNode &&
     !options.nodeTarget &&
+    !isLinaria &&
     callerCouldTargetWeb(callerTarget) &&
     process.env.NO_HOT_RELOAD !== 'true' &&
     process.env.NO_HOT_RELOAD !== true &&

--- a/packages/generator-js/src/webpack/index.ts
+++ b/packages/generator-js/src/webpack/index.ts
@@ -68,18 +68,6 @@ export default class WebpackGenerator extends InstallPeersMixin(
         'react-error-overlay': '6.0.9',
       },
     });
-    // TODO: remove once linaria master is fixed
-    this.packageJson.merge({
-      resolutions: {
-        '@linaria/babel-preset': '4.4.5',
-        '@linaria/core': '4.2.10',
-        '@linaria/webpack5-loader': '4.1.17',
-        '@linaria/react': '4.3.8',
-        '@linaria/shaker': '4.2.11',
-        '@linaria/utils': '4.3.4',
-        '@linaria/tags': '4.3.5',
-      },
-    });
   }
 
   async writingDependencies() {

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "@linaria/webpack5-loader": "4.1.17",
+    "@linaria/webpack5-loader": "5.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
     "@svgr/webpack": "^8.1.0",
     "@types/webpack-bundle-analyzer": "^4.6.0",
@@ -125,7 +125,7 @@
   "peerDependencies": {
     "@babel/core": "^6 || ^7 || ^8",
     "@hot-loader/react-dom": "^16.0.0 || ^17.0.0",
-    "@linaria/babel-preset": "^4.0.0",
+    "@linaria/babel-preset": "^5.0.0",
     "@storybook/react": "^6.2.0 || ^7.0.0-rc.0",
     "@types/react": "^16.0.0 || ^17.0.0 || ^18.0.0",
     "node-sass": "^7.0.1 || ^8.0.0 || ^9.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,7 @@
   "ignoreDeps": [
     "whatwg-fetch",
     "react-error-overlay",
-    "@ant-design/pro-layout",
-    "@linaria/babel-preset",
-    "@linaria/core",
-    "@linaria/react",
-    "@linaria/shaker",
-    "@linaria/tags",
-    "@linaria/utils",
-    "@linaria/webpack5-loader"
+    "@ant-design/pro-layout"
   ],
 
   "timezone": "America/Chicago",

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,7 +345,7 @@ __metadata:
   resolution: "@anansi/webpack-config@workspace:packages/webpack-config-anansi"
   dependencies:
     "@babel/runtime": ^7.17.2
-    "@linaria/webpack5-loader": 4.1.17
+    "@linaria/webpack5-loader": 5.0.0
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.11
     "@svgr/webpack": ^8.1.0
     "@types/node": ^20.0.0
@@ -412,7 +412,7 @@ __metadata:
   peerDependencies:
     "@babel/core": ^6 || ^7 || ^8
     "@hot-loader/react-dom": ^16.0.0 || ^17.0.0
-    "@linaria/babel-preset": ^4.0.0
+    "@linaria/babel-preset": ^5.0.0
     "@storybook/react": ^6.2.0 || ^7.0.0-rc.0
     "@types/react": ^16.0.0 || ^17.0.0 || ^18.0.0
     node-sass: ^7.0.1 || ^8.0.0 || ^9.0.0
@@ -636,7 +636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.22.20, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.20.2, @babel/core@npm:^7.21.3, @babel/core@npm:^7.22.9, @babel/core@npm:^7.7.5":
+"@babel/core@npm:7.22.20, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.21.3, @babel/core@npm:^7.22.15, @babel/core@npm:^7.22.9, @babel/core@npm:^7.7.5":
   version: 7.22.20
   resolution: "@babel/core@npm:7.22.20"
   dependencies:
@@ -673,7 +673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.20.4, @babel/generator@npm:^7.22.15, @babel/generator@npm:^7.22.9, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.22.15, @babel/generator@npm:^7.22.9, @babel/generator@npm:^7.7.2":
   version: 7.22.15
   resolution: "@babel/generator@npm:7.22.15"
   dependencies:
@@ -808,7 +808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.22.5":
+"@babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.22.5":
   version: 7.22.15
   resolution: "@babel/helper-module-imports@npm:7.22.15"
   dependencies:
@@ -1679,7 +1679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:7.22.15, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.19.6, @babel/plugin-transform-modules-commonjs@npm:^7.22.15":
+"@babel/plugin-transform-modules-commonjs@npm:7.22.15, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.22.15"
   dependencies:
@@ -1971,7 +1971,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.19.6, @babel/plugin-transform-runtime@npm:^7.22.15":
+"@babel/plugin-transform-runtime@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/plugin-transform-runtime@npm:7.22.15"
   dependencies:
@@ -2021,7 +2021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-template-literals@npm:^7.18.9, @babel/plugin-transform-template-literals@npm:^7.22.5":
+"@babel/plugin-transform-template-literals@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-template-literals@npm:7.22.5"
   dependencies:
@@ -2104,7 +2104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.20.2, @babel/preset-env@npm:^7.22.20, @babel/preset-env@npm:^7.22.9":
+"@babel/preset-env@npm:^7.20.2, @babel/preset-env@npm:^7.22.15, @babel/preset-env@npm:^7.22.20, @babel/preset-env@npm:^7.22.9":
   version: 7.22.20
   resolution: "@babel/preset-env@npm:7.22.20"
   dependencies:
@@ -2280,7 +2280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.18.10, @babel/template@npm:^7.22.15, @babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.4":
+"@babel/template@npm:^7.22.15, @babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3, @babel/template@npm:^7.4.4":
   version: 7.22.15
   resolution: "@babel/template@npm:7.22.15"
   dependencies:
@@ -2291,7 +2291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.20.1, @babel/traverse@npm:^7.22.15, @babel/traverse@npm:^7.22.20, @babel/traverse@npm:^7.22.8":
+"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.22.15, @babel/traverse@npm:^7.22.20, @babel/traverse@npm:^7.22.8":
   version: 7.22.20
   resolution: "@babel/traverse@npm:7.22.20"
   dependencies:
@@ -2309,7 +2309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.22.10, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.22.10, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.22.19
   resolution: "@babel/types@npm:7.22.19"
   dependencies:
@@ -3949,122 +3949,127 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@linaria/babel-preset@npm:4.4.5":
-  version: 4.4.5
-  resolution: "@linaria/babel-preset@npm:4.4.5"
+"@linaria/babel-preset@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/babel-preset@npm:5.0.0"
   dependencies:
-    "@babel/core": ^7.20.2
-    "@babel/generator": ^7.20.4
-    "@babel/helper-module-imports": ^7.18.6
-    "@babel/template": ^7.18.10
-    "@babel/traverse": ^7.20.1
-    "@babel/types": ^7.20.2
-    "@linaria/core": ^4.2.10
-    "@linaria/logger": ^4.0.0
-    "@linaria/shaker": ^4.2.11
-    "@linaria/tags": ^4.3.5
-    "@linaria/utils": ^4.3.4
+    "@babel/core": ^7.22.15
+    "@babel/generator": ^7.22.15
+    "@babel/helper-module-imports": ^7.22.15
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.22.15
+    "@babel/types": ^7.22.15
+    "@linaria/core": ^5.0.0
+    "@linaria/logger": ^5.0.0
+    "@linaria/shaker": ^5.0.0
+    "@linaria/tags": ^5.0.0
+    "@linaria/utils": ^5.0.0
     cosmiconfig: ^8.0.0
-    find-up: ^5.0.0
+    happy-dom: 10.8.0
     source-map: ^0.7.3
     stylis: ^3.5.4
-  checksum: 8dce78ec962a045872971f3f4a1ba091aa6dd00d8638fd0d4a98ab09733b05e9f4bdeca51ec1937d2e9cc325c9be3b73a78f801ffded48bafc0c7adf372c830a
+    ts-invariant: ^0.10.3
+  checksum: bb3b090d1d07d0c487b26dae48deaf4daeb3a7506fe07e23b8a2189361f6d03f28d958608b56bdb2764cb2e97f1bf15381bfee8236e7aaa308ab4542e4d44239
   languageName: node
   linkType: hard
 
-"@linaria/core@npm:4.2.10":
-  version: 4.2.10
-  resolution: "@linaria/core@npm:4.2.10"
+"@linaria/core@npm:5.0.0, @linaria/core@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/core@npm:5.0.0"
   dependencies:
-    "@linaria/logger": ^4.0.0
-    "@linaria/tags": ^4.3.5
-    "@linaria/utils": ^4.3.4
-  checksum: a30378a43f09daa16cb16bc374cce7c830e279dfdb7ebd6430c176db40ab11f8dd4fdb7245cf98ef7cc82160a58006d426d77d193efb6dec3ac889fe6943cf80
+    "@linaria/logger": ^5.0.0
+    "@linaria/tags": ^5.0.0
+    "@linaria/utils": ^5.0.0
+  checksum: b9496003d984d52e829a44144deb3def7f520f0be365739a17cddb7ad6e2bbbebd8c031bc7f93ba561abda6379646b8ce1b7de6ed460b5d4ed4f06fdd91b5671
   languageName: node
   linkType: hard
 
-"@linaria/logger@npm:^4.0.0":
-  version: 4.5.0
-  resolution: "@linaria/logger@npm:4.5.0"
+"@linaria/logger@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/logger@npm:5.0.0"
   dependencies:
-    debug: ^4.1.1
+    debug: ^4.3.4
     picocolors: ^1.0.0
-  checksum: 8a01717e4935244c44d0952442811a8c4fa57aade9b99ab811d30ecbef5261859839af9f0c78645b6549d40c97eef79754cd12a8436f54e4c2139635c60cab91
+  checksum: 92b345e0f1aeb7bcaf819268753d9c72ac266b1d9ed60163719ee8d873c7b7db2259a47e34cc7c45630b2264d6e2e8568a41c2c3972e020e11aee7d7538ab68a
   languageName: node
   linkType: hard
 
-"@linaria/react@npm:4.3.8":
-  version: 4.3.8
-  resolution: "@linaria/react@npm:4.3.8"
+"@linaria/react@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/react@npm:5.0.0"
   dependencies:
     "@emotion/is-prop-valid": ^1.2.0
-    "@linaria/core": ^4.2.10
-    "@linaria/tags": ^4.3.5
-    "@linaria/utils": ^4.3.4
+    "@linaria/core": ^5.0.0
+    "@linaria/tags": ^5.0.0
+    "@linaria/utils": ^5.0.0
+    minimatch: ^9.0.3
     react-html-attributes: ^1.4.6
     ts-invariant: ^0.10.3
   peerDependencies:
     react: ">=16"
-  checksum: 91f185d26a15f82e80f10743030c05b75d75b82f58eebb6ad619944e4d7df2e57af0c35a751169bfcb725ebca8afd41206e5bb6262676e6158c34845d1947c91
+  checksum: 73a11ae3134ca8c690055e035e93b6aef5517f4978f3878aed6bfd298b3d812633ca560b715f229bc7db3beec6e786eced2ef9d8a7e4ab7a8d44827bc5ce1081
   languageName: node
   linkType: hard
 
-"@linaria/shaker@npm:4.2.11":
-  version: 4.2.11
-  resolution: "@linaria/shaker@npm:4.2.11"
+"@linaria/shaker@npm:5.0.0, @linaria/shaker@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/shaker@npm:5.0.0"
   dependencies:
-    "@babel/core": ^7.20.2
-    "@babel/generator": ^7.20.4
-    "@babel/plugin-transform-modules-commonjs": ^7.19.6
-    "@babel/plugin-transform-runtime": ^7.19.6
-    "@babel/plugin-transform-template-literals": ^7.18.9
-    "@babel/preset-env": ^7.20.2
-    "@linaria/logger": ^4.0.0
-    "@linaria/utils": ^4.3.4
+    "@babel/core": ^7.22.15
+    "@babel/generator": ^7.22.15
+    "@babel/plugin-transform-modules-commonjs": ^7.22.15
+    "@babel/plugin-transform-runtime": ^7.22.15
+    "@babel/plugin-transform-template-literals": ^7.22.5
+    "@babel/preset-env": ^7.22.15
+    "@linaria/logger": ^5.0.0
+    "@linaria/utils": ^5.0.0
     babel-plugin-transform-react-remove-prop-types: ^0.4.24
     ts-invariant: ^0.10.3
-  checksum: 2cada6b3d31804110775dfeddb3afef4d586ee5bc4266a5ab784022bcb62a429e1b290678e030e7661ccc59524c27bfcb737ffd7fe0a6e86f3af061a097bca81
+  checksum: d834e2f061da8ab11b6b5b2c94813fde50dd4aeb9c9d0bba076463c4b027092b9e5d319976ed622e1f7b584f48c4aa25e7af7f5052d5e1e50798057d186378e6
   languageName: node
   linkType: hard
 
-"@linaria/tags@npm:4.3.5":
-  version: 4.3.5
-  resolution: "@linaria/tags@npm:4.3.5"
+"@linaria/tags@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/tags@npm:5.0.0"
   dependencies:
-    "@babel/generator": ^7.20.4
-    "@linaria/logger": ^4.0.0
-    "@linaria/utils": ^4.3.4
-  checksum: 0ae79c1fb3aaeb49b18234ea94d9ba2f497824d34c91f47f3e6b024409c744fff5e53ddd464d93a092348728483175e1d19dbc3e018640c738d956201c580366
+    "@babel/generator": ^7.22.15
+    "@linaria/logger": ^5.0.0
+    "@linaria/utils": ^5.0.0
+  checksum: 8af0cda9dad56fa87a3339d4a628f7e910d259359312a7564220ce98c8430fca9717e59ff7b43898b402cfc321d2496ec3fda3131c402bc37a7930501a824062
   languageName: node
   linkType: hard
 
-"@linaria/utils@npm:4.3.4":
-  version: 4.3.4
-  resolution: "@linaria/utils@npm:4.3.4"
+"@linaria/utils@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/utils@npm:5.0.0"
   dependencies:
-    "@babel/core": ^7.20.2
-    "@babel/plugin-proposal-export-namespace-from": ^7.18.9
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-modules-commonjs": ^7.19.6
-    "@babel/traverse": ^7.20.1
-    "@babel/types": ^7.20.2
-    "@linaria/logger": ^4.0.0
+    "@babel/core": ^7.22.15
+    "@babel/generator": ^7.22.15
+    "@babel/plugin-transform-modules-commonjs": ^7.22.15
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.22.15
+    "@babel/types": ^7.22.15
+    "@linaria/logger": ^5.0.0
     babel-merge: ^3.0.0
-  checksum: a1f95942929712ef3ed89fb296e6fe4a20288db86a7d54b7b4ab659a5cae30b092275c0e6e560f32ce02e45908471e0b8fabbf4a2c69f0a10b2313d13b1baa4e
+    find-up: ^5.0.0
+    minimatch: ^9.0.3
+  checksum: 66010a8e1f6fe85340b2d2dab23d2bfbc6ebb420c8c1d405f01b2112a8b4744b3dd16d21f9c0220148fe11eb35074a33fd26cdd0daed6cdff71e9a471515ddf4
   languageName: node
   linkType: hard
 
-"@linaria/webpack5-loader@npm:4.1.17":
-  version: 4.1.17
-  resolution: "@linaria/webpack5-loader@npm:4.1.17"
+"@linaria/webpack5-loader@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@linaria/webpack5-loader@npm:5.0.0"
   dependencies:
-    "@linaria/babel-preset": ^4.4.5
-    "@linaria/logger": ^4.0.0
+    "@linaria/babel-preset": ^5.0.0
+    "@linaria/logger": ^5.0.0
+    "@linaria/utils": ^5.0.0
     enhanced-resolve: ^5.3.1
     mkdirp: ^0.5.1
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 61752bda1b457a23357013dd3fbc4fe4c21cb15540a7003c5598338c4aca9194396d5117d35e57c69c78317e2c6349fd123022afed09fb5c23957e4c2c75bd53
+  checksum: bd5921b4de3772ccbca091a4fc86dd9016feedd2af073df1a5a9e2e64c8e64b95bddbc329eb55456b18e4e59ae713a4637acb09a5385babd6502ce72ba731beb
   languageName: node
   linkType: hard
 
@@ -11730,6 +11735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "cssdb@npm:^7.7.1":
   version: 7.7.1
   resolution: "cssdb@npm:7.7.1"
@@ -12744,6 +12756,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "entities@npm:4.5.0"
+  checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -13513,9 +13532,9 @@ __metadata:
     "@babel/core": ^7.21.3
     "@babel/plugin-transform-modules-commonjs": 7.22.15
     "@babel/runtime": 7.22.15
-    "@linaria/core": 4.2.10
-    "@linaria/react": 4.3.8
-    "@linaria/shaker": 4.2.11
+    "@linaria/core": 5.0.0
+    "@linaria/react": 5.0.0
+    "@linaria/shaker": 5.0.0
     "@types/babel__core": ^7.20.0
     "@types/classnames": 2.3.1
     "@types/eslint": ^8.21.3
@@ -13573,9 +13592,9 @@ __metadata:
     "@data-client/redux": 0.9.4
     "@data-client/rest": 0.9.5
     "@data-client/test": 0.9.2
-    "@linaria/core": 4.2.10
-    "@linaria/react": 4.3.8
-    "@linaria/shaker": 4.2.11
+    "@linaria/core": 5.0.0
+    "@linaria/react": 5.0.0
+    "@linaria/shaker": 5.0.0
     "@types/babel__core": 7.20.2
     "@types/classnames": 2.3.1
     "@types/eslint": 8.44.2
@@ -15356,6 +15375,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"happy-dom@npm:10.8.0":
+  version: 10.8.0
+  resolution: "happy-dom@npm:10.8.0"
+  dependencies:
+    css.escape: ^1.5.1
+    entities: ^4.5.0
+    iconv-lite: ^0.6.3
+    webidl-conversions: ^7.0.0
+    whatwg-encoding: ^2.0.0
+    whatwg-mimetype: ^3.0.0
+  checksum: 81ae160f475cf5d6b3ed0685e2bac6042a548c07b445a031c2460df985a27e8ae88c7a7189fb4a63307439c8871ad392e4a1b19d2a1ef8b0a06d5babcdba5f13
+  languageName: node
+  linkType: hard
+
 "hard-rejection@npm:^2.1.0":
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
@@ -15914,7 +15947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:


### PR DESCRIPTION
Linaria 5 introduced caller.name to determine when it is the caller. This allows us to disable react refresh in this case.