### PR TITLE
fix: Storybook builds by not running full loader on storybook virtua files

### DIFF
--- a/examples/concurrent/webpack.config.cjs
+++ b/examples/concurrent/webpack.config.cjs
@@ -5,13 +5,11 @@ const generateConfig = makeConfig({
   buildDir: 'dist/',
   serverDir: 'dist-server/',
   fontPreload: 'prefetch',
-  //libraryInclude: /(@pojo-router\/core|@anansi\/router)/,
+  libraryInclude: /(packages\/|@pojo-router\/core|@anansi\/router)/,
   babelLoader: {
-    rootMode: Object.prototype.hasOwnProperty.call(
-      process.versions,
-      'webcontainer',
-    )
-      ? 'root'
+    rootMode:
+      Object.prototype.hasOwnProperty.call(process.versions, 'webcontainer') ?
+        'root'
       : 'upward',
   },
 });

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -160,7 +160,7 @@ export default function makeBaseConfig({
         {
           test: /\.(t|j)sx?$/,
           include: [
-            new RegExp(basePath),
+            path.join(rootPath, basePath),
             path.join(rootPath, 'stories'),
             /\.storybook/,
             libraryInclude,

--- a/packages/webpack-config-anansi/src/storybook.js
+++ b/packages/webpack-config-anansi/src/storybook.js
@@ -98,7 +98,11 @@ export default function makeStorybookConfigGenerator(baseConfig) {
         ...envConfig.module,
         rules: [
           // js rules (worker and normal)
-          envConfig.module.rules[0],
+          {
+            test: envConfig.module.rules[0].test,
+            exclude: /storybook-stories.js/,
+            rules: [envConfig.module.rules[0]],
+          },
           // storybook node_module compiles
           libraryRule,
           // the rest of our rules


### PR DESCRIPTION
### Motivation

This is a workaround for https://github.com/Anber/wyw-in-js/issues/30 wyw-in-js not being able to process some of the info.

https://github.com/storybookjs/storybook/blob/f013ffeb03377c6e1b76a9aabd94c180e3e3ef38/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts#L52 includes some storybook specific virtual files that are not compatible. However, these are not user files so there is no reason to run our loader processing on them - we can simply exclude those and let them fallback to how storybook rules work.

### Solution

- Explicitly exclude known problematic https://github.com/storybookjs/storybook/blob/f013ffeb03377c6e1b76a9aabd94c180e3e3ef38/code/builders/builder-webpack5/src/preview/virtual-module-mapping.ts#L52 in storybook rule
- Update ts/js rule to more correctly match only files in project's `basePath`