### PR TITLE
enhance: Fix 'Class fields are not enabled.' by using latest decorators standard

### DIFF
--- a/packages/babel-preset-anansi/CHANGELOG.md
+++ b/packages/babel-preset-anansi/CHANGELOG.md
@@ -9,6 +9,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Flow is no longer supported
 * Double check your class transforms in case your use-case is different than our tests.
+* Decorators targets '2023-05' of the spec by default (from '2018-09' previously)
+  * See more https://babeljs.io/docs/babel-plugin-proposal-decorators#version
+  * If you want to continue targeting an older version, you will need to manually add `@babel/plugin-transform-class-properties`
+  * 'loose' no longer makes the default decorators spec 'legacy'
 
 ### 💅 Enhancement
 

--- a/packages/babel-preset-anansi/README.md
+++ b/packages/babel-preset-anansi/README.md
@@ -185,7 +185,7 @@ Be sure to install babel-minify as it is listed as an optional peerdependency he
 
 ### [decoratorsOptions](https://babeljs.io/docs/en/babel-plugin-proposal-decorators#options)
 
-- `version`: "2021-12", "2018-09" or "legacy". defaults to 'legacy' if 'loose' is true, otherwise "2018-09"
+- `version`: "2023-05", "2023-01", "2022-03", "2021-12", "2018-09" or "legacy". defaults to "2023-05"
 - `decoratorsBeforeExport`
 
 ### reactRequire: bool = true


### PR DESCRIPTION
"Class fields are not enabled. Please add `@babel/plugin-transform-class-properties` to your configuration."

appears when not transforming, due to the default decorators targeting a version that always expects them to exist.

Simply targeting the latest fixes this. This should be considered a breaking change in v5

Breaking:

* Decorators targets '2023-05' of the spec by default (from '2018-09' previously)
  * See more https://babeljs.io/docs/babel-plugin-proposal-decorators#version
  * If you want to continue targeting an older version, you will need to manually add `@babel/plugin-transform-class-properties`
  * `loose` no longer changes the default spec target (used to be 'legacy')

Other changes:
- Setting decoratorsOptions to target legacy, will force class transforms to be enabled, as [this is required](https://babeljs.io/docs/babel-plugin-proposal-decorators#note-compatibility-with-babelplugin-transform-class-properties).