### PR TITLE
internal: Test builds targetting different browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker: &docker
@@ -68,6 +68,16 @@ jobs:
           at: ~/
       - run: yarn workspaces foreach -Wv --include 'example-*' run build
 
+  build_matrix:
+    parameters:
+      browserslist-env:
+        type: string
+    docker: *docker
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: BROWSERSLIST_ENV='<< parameters.browserslist-env >>' yarn workspace example-typescript run build
+
   start_dev:
     docker: *docker
     steps:
@@ -103,6 +113,12 @@ workflows:
           requires:
             - build
       - build_production:
+          requires:
+            - build
+      - build_matrix:
+          matrix:
+            parameters:
+              browserslist-env: ["2018", "2020", "2022"]
           requires:
             - build
       - start_dev:

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack serve --mode=development",
     "start:prod": "serve ./dist",
-    "build": "BROWSERSLIST_ENV='2020' webpack --mode=production",
+    "build": "webpack --mode=production",
     "build:server": "webpack --mode=production --target=node",
     "build:clean": "rm -rf dist && rm -rf server_assets",
     "build:analyze": "webpack --mode=production --env analyze",


### PR DESCRIPTION
Other than testing recent targets, we want to ensure targetting various legacy configs works.

"2018", "2020", "2022"