### PR TITLE
Use react's jsx-runtime directly by default

### DIFF
--- a/packages/babel-preset-anansi/README.md
+++ b/packages/babel-preset-anansi/README.md
@@ -203,6 +203,8 @@ Setting to false disables this optimization altogether. Note: this is only ever 
 
 ### hasJsxRuntime
 
+** Defaults to `true`. Set this to `false` explicitly to use with React <=16.13 **
+
 Use [new jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 Available in React >16.14.
 

--- a/packages/babel-preset-anansi/index.js
+++ b/packages/babel-preset-anansi/index.js
@@ -44,7 +44,9 @@ function buildPreset(api, options = {}) {
     : undefined;
   const hasJsxRuntime = Boolean(
     api.caller(
-      caller => (!!caller && caller.hasJsxRuntime) || options.hasJsxRuntime,
+      caller =>
+        // default to true - only allow overrides of false
+        ((!!caller && caller.hasJsxRuntime) || options.hasJsxRuntime) !== false,
     ),
   );
 


### PR DESCRIPTION
BREAKING CHANGE: hasJsxRuntime defaults to true