### PR TITLE
feat: useController -> useRouter

### DIFF
--- a/examples/concurrent/src/app/App.tsx
+++ b/examples/concurrent/src/app/App.tsx
@@ -1,10 +1,9 @@
-import { memo } from 'react';
-import { Layout, Spin } from 'antd';
-import { MatchedRoute, useController } from '@anansi/router';
-import { styled } from '@linaria/react';
-import 'antd/dist/reset.css';
-
+import { MatchedRoute, useRouter } from '@anansi/router';
 import { AsyncBoundary } from '@data-client/react';
+import { styled } from '@linaria/react';
+import { Layout, Spin } from 'antd';
+import { memo } from 'react';
+import 'antd/dist/reset.css';
 
 import Nav from 'navigation';
 
@@ -19,7 +18,7 @@ const Wrapper = styled(Layout)`
 `;
 
 const App = () => {
-  const router = useController();
+  const router = useRouter();
   return (
     <Wrapper className="ant-layout-has-sider">
       <Nav />

--- a/examples/concurrent/src/app/demo.tsx
+++ b/examples/concurrent/src/app/demo.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+
 import { PlaceholderEntity } from 'resources/PlaceholderBaseResource';
 
 export const demoContext = createContext({

--- a/examples/concurrent/src/index.tsx
+++ b/examples/concurrent/src/index.tsx
@@ -7,6 +7,7 @@ import {
   appSpout,
 } from '@anansi/core';
 import { useController } from '@data-client/react';
+
 import app from 'app';
 
 import { createRouter } from './routing';

--- a/packages/pojo-router/README.md
+++ b/packages/pojo-router/README.md
@@ -83,6 +83,6 @@ Given a path, this returns all the metadata for routes that match.
 
 Get current location
 
-## useController()
+## useRouter()
 
-Return the [Controller](#controller) that can be used for computations
+Return the [RouteController](#controller) that can be used for computations

--- a/packages/pojo-router/src/Link.tsx
+++ b/packages/pojo-router/src/Link.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 
-import { useController } from './hooks.js';
+import { useRouter } from './hooks.js';
 
 type ComponentConstraint =
   | keyof JSX.IntrinsicElements
@@ -31,7 +31,7 @@ export default function Link<C extends ComponentConstraint = 'a'>({
   onClick,
   ...rest
 }: LinkProps<C>) {
-  const controller = useController();
+  const controller = useRouter();
   const pathname = controller.buildPath(name, props);
   const shouldHandle =
     !Object.prototype.hasOwnProperty.call(rest, 'target') ||

--- a/packages/pojo-router/src/hooks.tsx
+++ b/packages/pojo-router/src/hooks.tsx
@@ -15,12 +15,12 @@ export function useLocationSearch<K extends string = ''>(
   return search as any;
 }
 
-export function useController() {
+export function useRouter() {
   return useContext(ControllerContext);
 }
 
 export function useRoutes<Route>(): Route[] {
-  const controller = useController();
+  const controller = useRouter();
   const location = useLocation();
 
   return useMemo(


### PR DESCRIPTION
BREAKING CHANGE: useController renamed to useRouter

Controller naming is too generic. This makes it easier to work with other packages like data-client.