### PR TITLE
feat: Improve polyfill packaging

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ const { resolvePath } = require('babel-plugin-module-resolver');
 
 module.exports = function (api) {
   api.cache.using(
-    () => process.env.NODE_ENV + process.env.BROWSERSLIST_ENV + '3',
+    () => process.env.NODE_ENV + process.env.BROWSERSLIST_ENV + '5',
   );
   const options = { loose: true, hasJsxRuntime: true };
   if (process.env.NODE_ENV === 'test') {

--- a/examples/concurrent/package.json
+++ b/examples/concurrent/package.json
@@ -47,7 +47,7 @@
     "@anansi/router": "^0.10.10",
     "@ant-design/cssinjs": "1.23.0",
     "@ant-design/icons": "^5.0.1",
-    "@babel/runtime": "7.26.7",
+    "@babel/runtime-corejs3": "7.26.7",
     "@data-client/endpoint": "0.14.17",
     "@data-client/hooks": "0.2.0",
     "@data-client/img": "0.14.15",

--- a/examples/linaria/package.json
+++ b/examples/linaria/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.26.3",
-    "@babel/runtime": "7.26.7",
+    "@babel/runtime-corejs3": "7.26.7",
     "@linaria/core": "6.2.0",
     "@linaria/react": "6.2.1",
     "classnames": "2.5.1",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -59,7 +59,7 @@
     "@ant-design/cssinjs": "^1.7.1",
     "@ant-design/icons": "^5.0.1",
     "@ant-design/pro-layout": "7.12.3",
-    "@babel/runtime": "7.26.7",
+    "@babel/runtime-corejs3": "7.26.7",
     "@data-client/graphql": "0.14.17",
     "@data-client/react": "0.14.18",
     "@data-client/rest": "0.14.18",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@anansi/eslint-plugin": "workspace:*",
     "@babel/cli": "7.26.4",
     "@babel/core": "7.26.7",
+    "@babel/runtime-corejs3": "^7.26.7",
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
     "@lerna-lite/cli": "3.11.0",

--- a/packages/babel-preset-anansi/README.md
+++ b/packages/babel-preset-anansi/README.md
@@ -100,7 +100,24 @@ are included:
 
 ## Options
 
-### nodeTarget : ?string = undefined
+Options to the preset. These are configured like so
+
+```json
+{
+  "presets": [
+    [
+      "@anansi",
+      {
+        "optionName": "optionValue"
+      }
+    ]
+  ]
+}
+```
+
+### Target Environment
+
+#### nodeTarget : ?string = undefined
 
 > Deprecated: Prefer using [top-level](https://babel.dev/blog/2021/02/22/7.13.0#top-level-targets-option-12189httpsgithubcombabelbabelpull12189-rfchttpsgithubcombabelrfcspull2) `targets` instead
 
@@ -115,7 +132,7 @@ Will run to target node instead of browsers. Specify a [valid node string](https
 
 If unset, will automatically target current node version when webpack is targetting node.
 
-### targets : ?object = undefined
+#### targets : ?object = undefined
 
 > Deprecated: Prefer using [top-level](https://babel.dev/blog/2021/02/22/7.13.0#top-level-targets-option-12189httpsgithubcombabelbabelpull12189-rfchttpsgithubcombabelrfcspull2) `targets` instead
 
@@ -129,18 +146,88 @@ Use a [browserslist config](https://github.com/browserslist/browserslist#package
 
 Feel free to use the [anansi browserlist config](/packages/browserslist-config-anansi).
 
-### modules: "amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false = false
+#### modules: "amd" | "umd" | "systemjs" | "commonjs" | "cjs" | "auto" | false = false
 
 Enable transformation of ES module syntax to another module type.
 
 By default this tries to infer if ESModules is supported and if so, keep ESM. If this detection isn't
 working correct, feel free to explicitly set.
 
-### BABEL_MODULES
+#### BABEL_MODULES
 
 This will override or set `modules` option from above.
 
-### useESModules: boolean = !(env === 'test' || options.nodeTarget)
+### Polyfills
+
+#### polyfillMethod
+
+‘usage-global’ | ‘entry-global’ | ‘usage-pure’ | false | undefined
+
+This determines how to handle polyfills.
+
+[plugin reference](https://github.com/babel/babel-polyfills/blob/main/docs/migration.md)
+
+##### undefined
+
+This is the default - it will automatically determine a reasonable default based on other factors.
+
+'usage-pure' when detecting 'library build' (@babel/cli or caller.library is true)
+
+Otherwise, if 'core-js' and '@babel/runtime' package are found, 'usage-global'.
+
+If just 'core-js' is found, 'usage-entry'
+
+Otherwise `false`.
+
+##### usage-entry
+
+Transforms core-js import into only the polyfills needed for the target environment. This can be best when
+a good code-splitting strategy for polyfills is in the place.
+
+Turns
+
+```js
+import 'core-js'
+```
+
+into
+
+```js
+import 'core-js/es/object/has-own'
+// whatever else is needed for target env
+```
+
+Like [useBuiltins: entry](https://babeljs.io/docs/babel-preset-env#usebuiltins-entry) for babel-preset-env.
+
+##### usage-global
+
+Only imports polyfills as-needed both based on target environment and usage.
+
+```js
+import 'core-js/es/object/has-own'
+Object.hasOwn({ a: 1 }, 'a')
+```
+
+Like [useBuiltins: usage](https://babeljs.io/docs/babel-preset-env#usebuiltins-usage) for babel-preset-env.
+
+##### usage-pure
+
+This doesn't pollute the global scope. This is recommended when bundling libraries.
+
+```js
+import _Object$hasOwn from "core-js-pure/stable/object/has-own.js"
+_Object$hasOwn({ a: 1 }, 'a')
+```
+
+##### false
+
+Do not perform any transforms related to core-js or polyfills.
+
+#### corejsVersion
+
+Specifies the core-js version to target. Without specified will use the version found by importing.
+
+#### useESModules: boolean = !(env === 'test' || options.nodeTarget)
 
 This uses the es6 module version of [@babel/runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules).
 "This allows for smaller builds in module systems like webpack, since it doesn't need to preserve commonjs semantics."
@@ -149,7 +236,7 @@ By default, tries to infer whether this can be used.
 
 Set this to false for maximum compatibility.
 
-### [useBuiltIns](https://babeljs.io/docs/en/babel-preset-env#usebuiltins): "usage" | "entry" | false = "entry"
+#### [useBuiltIns](https://babeljs.io/docs/en/babel-preset-env#usebuiltins): "usage" | "entry" | false = "entry"
 
 This option configures how @anansi/babel-preset handles polyfills. Both `usage` and `entry` will
 only include polyfills needed for the target.
@@ -160,35 +247,37 @@ adding your own import of core-js. You can even import pieces selectively.
 `usage` will add imports everywhere a file is used, which can make it harder to split polyfills if they
 are not needed.
 
-### [corejs](https://babeljs.io/docs/en/babel-preset-env#corejs): { version: 3, proposals: true }
+#### [corejs](https://babeljs.io/docs/en/babel-preset-env#corejs): { version: 3, proposals: true }
 
 Which core-js version to use when useBuiltIns is not false
 
-### runtimePkg = "@babel/runtime"
+#### runtimePkg = "@babel/runtime"
 
 Can be `@babel/runtime-corejs3` or `@babel/runtime-corejs2`. Using the corejs version will
 add imports to the 'pure' form of core-js, which doesn't change global objects. This will however
 result in heavily increased bundle sizes, so it's generally preferred to stay with the default.
 
-### minify: bool = false
+### Additional Transforms
+
+#### minify: bool = false
 
 Setting this to true will run the minifier [babel-minify](https://github.com/babel/babel-minify)
 
 Be sure to install babel-minify as it is listed as an optional peerdependency here.
 
-### loose: bool = false
+#### loose: bool = false
 
 - class properties
 - private methods
 - all things in preset-env
 - legacy decorators
 
-### [decoratorsOptions](https://babeljs.io/docs/en/babel-plugin-proposal-decorators#options)
+#### [decoratorsOptions](https://babeljs.io/docs/en/babel-plugin-proposal-decorators#options)
 
 - `version`: "2023-05", "2023-01", "2022-03", "2021-12", "2018-09" or "legacy". defaults to "2023-05"
 - `decoratorsBeforeExport`
 
-### reactCompiler: {compilationMode?: "annotation"}
+#### reactCompiler: {compilationMode?: "annotation"}
 
 Run the [React Compiler](https://react.dev/learn/react-compiler). This is still experimental - be sure to
 [check compatibility](https://react.dev/learn/react-compiler#checking-compatibility) before turning this on.
@@ -199,12 +288,12 @@ By default does not run. Include empty object or a configuration to turn on.
 
 ** This only runs in production **
 
-### reactConstantElementsOptions: { allowMutablePropsOnTags?: string[] } | false
+#### reactConstantElementsOptions: { allowMutablePropsOnTags?: string[] } | false
 
 Configures the options for [react-constant-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements).
 Setting to false disables this optimization altogether. Note: this is only ever used in production mode
 
-### hasJsxRuntime
+#### hasJsxRuntime
 
 ** Defaults to `true`. Set this to `false` explicitly to use with React <=16.13 **
 
@@ -217,7 +306,7 @@ Available in React >16.14.
 
 > Note: This is automatically set when using anansi webpack using the [caller config](https://babeljs.io/docs/en/options#caller)
 
-### tsConfigPath
+#### tsConfigPath
 
 Specifies the tsconfig.json file location to automatically apply [tsconfig path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping).
 
@@ -233,7 +322,7 @@ module.exports = {
 
 Merges with [module resolver](#module-resolver-options) options
 
-#### TS_CONFIG_PATH
+##### TS_CONFIG_PATH
 
 Overrides `tsConfigPath`.
 
@@ -241,9 +330,9 @@ Overrides `tsConfigPath`.
 export TS_CONFIG_PATH = './tsconfig.json'
 ```
 
-## module-resolver options
+### module-resolver options
 
-### resolverRoot
+#### resolverRoot
 
 Sets the root [root](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md#root).
 
@@ -251,7 +340,7 @@ Sets the root [root](https://github.com/tleunen/babel-plugin-module-resolver/blo
 root = ['./src'];
 ```
 
-#### RESOLVER_ROOT
+##### RESOLVER_ROOT
 
 Overrides `resolverRoot`.
 
@@ -259,7 +348,7 @@ Overrides `resolverRoot`.
 export RESOLVER_ROOT = './src'
 ```
 
-### resolverAlias
+#### resolverAlias
 
 JSON representation of the [alias](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md#alias) object option.
 
@@ -270,7 +359,7 @@ JSON representation of the [alias](https://github.com/tleunen/babel-plugin-modul
 }
 ```
 
-#### RESOLVER_ALIAS
+##### RESOLVER_ALIAS
 
 If `RESOLVER_ALIAS` env is set, it will override this setting. Be sure to JSON encode.
 
@@ -278,14 +367,14 @@ If `RESOLVER_ALIAS` env is set, it will override this setting. Be sure to JSON e
 export RESOLVER_ALIAS = '{"underscore":"lodash","^@namespace/foo-(.+)":"packages/\\\\1"}'
 ```
 
-### resolver
+#### resolver
 
 Full control of [module-resolver options](https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md).
 Sets as default, so `resolverRoot` and `resolverAlias` will override `root` and `alias` respectively.
 
-## root-import options
+### root-import options
 
-### rootPathSuffix: string = './src'
+#### rootPathSuffix: string = './src'
 
 Enables importing from project root with `~/my/path` rather than using relative paths. Override
 this if your project root is in another directory.
@@ -301,20 +390,14 @@ When using with typescript, be sure to add to tsconfig.json:
 }
 ```
 
-### rootPathPrefix: string = '~/'
+#### rootPathPrefix: string = '~/'
 
 Configures what prefix is used to trigger root imports.
 
-### rootPathRoot: undefined
+#### rootPathRoot: undefined
 
 [Controls the root.](https://www.npmjs.com/package/babel-plugin-root-import#custom-root)
 No value (undefined) means use current working directory.
 
 Sending `__dirname` from a `.babelrc.js` can be useful to ensure consistency no matter
 where babel starts running from.
-
-### Polyfills
-
-Usage of features that require polyfills is automatically detected and included in many cases. However,
-some features (`Intl`, `requestIdleCallback` and `fetch`) are not. We recommend using
-[@anansi/polyfill](https://www.npmjs.com/package/@anansi/polyfill) to cover those cases.

--- a/packages/babel-preset-anansi/__snapshots__/transform2018.test.js.snap
+++ b/packages/babel-preset-anansi/__snapshots__/transform2018.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`buildPreset - Babel Transform should apply class properties transform when not loose 1`] = `
-"import _defineProperty from "@babel/runtime/helpers/defineProperty";
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
 class MyClass {
   constructor() {
     _defineProperty(this, "myProp", 42);
@@ -9,10 +9,351 @@ class MyClass {
 }"
 `;
 
+exports[`buildPreset - Babel Transform should import Object.hasOwn() polyfill with usage-global 1`] = `
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
+import "core-js/modules/es.object.has-own.js";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}
+console.log(Object.hasOwn({
+  a: 1
+}, 'a') ? 'yes' : 'no');"
+`;
+
 exports[`buildPreset - Babel Transform should not apply class properties transform when loose 1`] = `
 "class MyClass {
   constructor() {
     this.myProp = 42;
+  }
+}"
+`;
+
+exports[`buildPreset - Babel Transform should not polyfill when polyfillMethod: \`false\` 1`] = `
+"import _defineProperty from "@babel/runtime/helpers/defineProperty";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}
+console.log(Object.hasOwn({
+  a: 1
+}, 'a') ? 'yes' : 'no');"
+`;
+
+exports[`buildPreset - Babel Transform should not transform entry polyfill import when polyfillMethod: \`false\` 1`] = `
+"import _defineProperty from "@babel/runtime/helpers/defineProperty";
+import 'core-js';
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}"
+`;
+
+exports[`buildPreset - Babel Transform should select polyfill entries with entry-global 1`] = `
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
+import "core-js/modules/es.symbol.description.js";
+import "core-js/modules/es.symbol.async-iterator.js";
+import "core-js/modules/es.symbol.match.js";
+import "core-js/modules/es.symbol.match-all.js";
+import "core-js/modules/es.symbol.replace.js";
+import "core-js/modules/es.symbol.search.js";
+import "core-js/modules/es.symbol.split.js";
+import "core-js/modules/es.error.cause.js";
+import "core-js/modules/es.aggregate-error.js";
+import "core-js/modules/es.aggregate-error.cause.js";
+import "core-js/modules/es.array.at.js";
+import "core-js/modules/es.array.find-last.js";
+import "core-js/modules/es.array.find-last-index.js";
+import "core-js/modules/es.array.flat.js";
+import "core-js/modules/es.array.flat-map.js";
+import "core-js/modules/es.array.includes.js";
+import "core-js/modules/es.array.iterator.js";
+import "core-js/modules/es.array.push.js";
+import "core-js/modules/es.array.reduce.js";
+import "core-js/modules/es.array.reduce-right.js";
+import "core-js/modules/es.array.reverse.js";
+import "core-js/modules/es.array.sort.js";
+import "core-js/modules/es.array.to-reversed.js";
+import "core-js/modules/es.array.to-sorted.js";
+import "core-js/modules/es.array.to-spliced.js";
+import "core-js/modules/es.array.unscopables.flat.js";
+import "core-js/modules/es.array.unscopables.flat-map.js";
+import "core-js/modules/es.array.unshift.js";
+import "core-js/modules/es.array.with.js";
+import "core-js/modules/es.array-buffer.constructor.js";
+import "core-js/modules/es.array-buffer.slice.js";
+import "core-js/modules/es.array-buffer.detached.js";
+import "core-js/modules/es.array-buffer.transfer.js";
+import "core-js/modules/es.array-buffer.transfer-to-fixed-length.js";
+import "core-js/modules/es.global-this.js";
+import "core-js/modules/es.iterator.constructor.js";
+import "core-js/modules/es.iterator.drop.js";
+import "core-js/modules/es.iterator.every.js";
+import "core-js/modules/es.iterator.filter.js";
+import "core-js/modules/es.iterator.find.js";
+import "core-js/modules/es.iterator.flat-map.js";
+import "core-js/modules/es.iterator.for-each.js";
+import "core-js/modules/es.iterator.from.js";
+import "core-js/modules/es.iterator.map.js";
+import "core-js/modules/es.iterator.reduce.js";
+import "core-js/modules/es.iterator.some.js";
+import "core-js/modules/es.iterator.take.js";
+import "core-js/modules/es.iterator.to-array.js";
+import "core-js/modules/es.json.stringify.js";
+import "core-js/modules/es.map.group-by.js";
+import "core-js/modules/es.math.hypot.js";
+import "core-js/modules/es.number.parse-float.js";
+import "core-js/modules/es.number.parse-int.js";
+import "core-js/modules/es.number.to-exponential.js";
+import "core-js/modules/es.number.to-fixed.js";
+import "core-js/modules/es.object.assign.js";
+import "core-js/modules/es.object.from-entries.js";
+import "core-js/modules/es.object.group-by.js";
+import "core-js/modules/es.object.has-own.js";
+import "core-js/modules/es.parse-float.js";
+import "core-js/modules/es.parse-int.js";
+import "core-js/modules/es.promise.js";
+import "core-js/modules/es.promise.all-settled.js";
+import "core-js/modules/es.promise.any.js";
+import "core-js/modules/es.promise.finally.js";
+import "core-js/modules/es.promise.try.js";
+import "core-js/modules/es.promise.with-resolvers.js";
+import "core-js/modules/es.reflect.set.js";
+import "core-js/modules/es.reflect.to-string-tag.js";
+import "core-js/modules/es.regexp.constructor.js";
+import "core-js/modules/es.regexp.dot-all.js";
+import "core-js/modules/es.regexp.exec.js";
+import "core-js/modules/es.regexp.flags.js";
+import "core-js/modules/es.regexp.test.js";
+import "core-js/modules/es.regexp.to-string.js";
+import "core-js/modules/es.set.difference.v2.js";
+import "core-js/modules/es.set.intersection.v2.js";
+import "core-js/modules/es.set.is-disjoint-from.v2.js";
+import "core-js/modules/es.set.is-subset-of.v2.js";
+import "core-js/modules/es.set.is-superset-of.v2.js";
+import "core-js/modules/es.set.symmetric-difference.v2.js";
+import "core-js/modules/es.set.union.v2.js";
+import "core-js/modules/es.string.at-alternative.js";
+import "core-js/modules/es.string.ends-with.js";
+import "core-js/modules/es.string.includes.js";
+import "core-js/modules/es.string.is-well-formed.js";
+import "core-js/modules/es.string.match.js";
+import "core-js/modules/es.string.match-all.js";
+import "core-js/modules/es.string.replace.js";
+import "core-js/modules/es.string.replace-all.js";
+import "core-js/modules/es.string.search.js";
+import "core-js/modules/es.string.split.js";
+import "core-js/modules/es.string.starts-with.js";
+import "core-js/modules/es.string.to-well-formed.js";
+import "core-js/modules/es.string.trim.js";
+import "core-js/modules/es.string.trim-end.js";
+import "core-js/modules/es.string.trim-start.js";
+import "core-js/modules/es.typed-array.float32-array.js";
+import "core-js/modules/es.typed-array.float64-array.js";
+import "core-js/modules/es.typed-array.int8-array.js";
+import "core-js/modules/es.typed-array.int16-array.js";
+import "core-js/modules/es.typed-array.int32-array.js";
+import "core-js/modules/es.typed-array.uint8-array.js";
+import "core-js/modules/es.typed-array.uint8-clamped-array.js";
+import "core-js/modules/es.typed-array.uint16-array.js";
+import "core-js/modules/es.typed-array.uint32-array.js";
+import "core-js/modules/es.typed-array.at.js";
+import "core-js/modules/es.typed-array.fill.js";
+import "core-js/modules/es.typed-array.find-last.js";
+import "core-js/modules/es.typed-array.find-last-index.js";
+import "core-js/modules/es.typed-array.from.js";
+import "core-js/modules/es.typed-array.of.js";
+import "core-js/modules/es.typed-array.set.js";
+import "core-js/modules/es.typed-array.sort.js";
+import "core-js/modules/es.typed-array.to-locale-string.js";
+import "core-js/modules/es.typed-array.to-reversed.js";
+import "core-js/modules/es.typed-array.to-sorted.js";
+import "core-js/modules/es.typed-array.with.js";
+import "core-js/modules/es.weak-map.js";
+import "core-js/modules/esnext.suppressed-error.constructor.js";
+import "core-js/modules/esnext.array.from-async.js";
+import "core-js/modules/esnext.array.filter-out.js";
+import "core-js/modules/esnext.array.filter-reject.js";
+import "core-js/modules/esnext.array.group.js";
+import "core-js/modules/esnext.array.group-by.js";
+import "core-js/modules/esnext.array.group-by-to-map.js";
+import "core-js/modules/esnext.array.group-to-map.js";
+import "core-js/modules/esnext.array.is-template-object.js";
+import "core-js/modules/esnext.array.last-index.js";
+import "core-js/modules/esnext.array.last-item.js";
+import "core-js/modules/esnext.array.unique-by.js";
+import "core-js/modules/esnext.async-disposable-stack.constructor.js";
+import "core-js/modules/esnext.async-iterator.constructor.js";
+import "core-js/modules/esnext.async-iterator.as-indexed-pairs.js";
+import "core-js/modules/esnext.async-iterator.async-dispose.js";
+import "core-js/modules/esnext.async-iterator.drop.js";
+import "core-js/modules/esnext.async-iterator.every.js";
+import "core-js/modules/esnext.async-iterator.filter.js";
+import "core-js/modules/esnext.async-iterator.find.js";
+import "core-js/modules/esnext.async-iterator.flat-map.js";
+import "core-js/modules/esnext.async-iterator.for-each.js";
+import "core-js/modules/esnext.async-iterator.from.js";
+import "core-js/modules/esnext.async-iterator.indexed.js";
+import "core-js/modules/esnext.async-iterator.map.js";
+import "core-js/modules/esnext.async-iterator.reduce.js";
+import "core-js/modules/esnext.async-iterator.some.js";
+import "core-js/modules/esnext.async-iterator.take.js";
+import "core-js/modules/esnext.async-iterator.to-array.js";
+import "core-js/modules/esnext.bigint.range.js";
+import "core-js/modules/esnext.composite-key.js";
+import "core-js/modules/esnext.composite-symbol.js";
+import "core-js/modules/esnext.data-view.get-float16.js";
+import "core-js/modules/esnext.data-view.get-uint8-clamped.js";
+import "core-js/modules/esnext.data-view.set-float16.js";
+import "core-js/modules/esnext.data-view.set-uint8-clamped.js";
+import "core-js/modules/esnext.disposable-stack.constructor.js";
+import "core-js/modules/esnext.error.is-error.js";
+import "core-js/modules/esnext.function.demethodize.js";
+import "core-js/modules/esnext.function.is-callable.js";
+import "core-js/modules/esnext.function.is-constructor.js";
+import "core-js/modules/esnext.function.metadata.js";
+import "core-js/modules/esnext.function.un-this.js";
+import "core-js/modules/esnext.iterator.as-indexed-pairs.js";
+import "core-js/modules/esnext.iterator.concat.js";
+import "core-js/modules/esnext.iterator.dispose.js";
+import "core-js/modules/esnext.iterator.indexed.js";
+import "core-js/modules/esnext.iterator.range.js";
+import "core-js/modules/esnext.iterator.to-async.js";
+import "core-js/modules/esnext.json.is-raw-json.js";
+import "core-js/modules/esnext.json.parse.js";
+import "core-js/modules/esnext.json.raw-json.js";
+import "core-js/modules/esnext.map.delete-all.js";
+import "core-js/modules/esnext.map.emplace.js";
+import "core-js/modules/esnext.map.every.js";
+import "core-js/modules/esnext.map.filter.js";
+import "core-js/modules/esnext.map.find.js";
+import "core-js/modules/esnext.map.find-key.js";
+import "core-js/modules/esnext.map.from.js";
+import "core-js/modules/esnext.map.get-or-insert.js";
+import "core-js/modules/esnext.map.get-or-insert-computed.js";
+import "core-js/modules/esnext.map.includes.js";
+import "core-js/modules/esnext.map.key-by.js";
+import "core-js/modules/esnext.map.key-of.js";
+import "core-js/modules/esnext.map.map-keys.js";
+import "core-js/modules/esnext.map.map-values.js";
+import "core-js/modules/esnext.map.merge.js";
+import "core-js/modules/esnext.map.of.js";
+import "core-js/modules/esnext.map.reduce.js";
+import "core-js/modules/esnext.map.some.js";
+import "core-js/modules/esnext.map.update.js";
+import "core-js/modules/esnext.map.update-or-insert.js";
+import "core-js/modules/esnext.map.upsert.js";
+import "core-js/modules/esnext.math.clamp.js";
+import "core-js/modules/esnext.math.deg-per-rad.js";
+import "core-js/modules/esnext.math.degrees.js";
+import "core-js/modules/esnext.math.fscale.js";
+import "core-js/modules/esnext.math.f16round.js";
+import "core-js/modules/esnext.math.iaddh.js";
+import "core-js/modules/esnext.math.imulh.js";
+import "core-js/modules/esnext.math.isubh.js";
+import "core-js/modules/esnext.math.rad-per-deg.js";
+import "core-js/modules/esnext.math.radians.js";
+import "core-js/modules/esnext.math.scale.js";
+import "core-js/modules/esnext.math.seeded-prng.js";
+import "core-js/modules/esnext.math.signbit.js";
+import "core-js/modules/esnext.math.sum-precise.js";
+import "core-js/modules/esnext.math.umulh.js";
+import "core-js/modules/esnext.number.from-string.js";
+import "core-js/modules/esnext.number.range.js";
+import "core-js/modules/esnext.object.iterate-entries.js";
+import "core-js/modules/esnext.object.iterate-keys.js";
+import "core-js/modules/esnext.object.iterate-values.js";
+import "core-js/modules/esnext.observable.js";
+import "core-js/modules/esnext.reflect.define-metadata.js";
+import "core-js/modules/esnext.reflect.delete-metadata.js";
+import "core-js/modules/esnext.reflect.get-metadata.js";
+import "core-js/modules/esnext.reflect.get-metadata-keys.js";
+import "core-js/modules/esnext.reflect.get-own-metadata.js";
+import "core-js/modules/esnext.reflect.get-own-metadata-keys.js";
+import "core-js/modules/esnext.reflect.has-metadata.js";
+import "core-js/modules/esnext.reflect.has-own-metadata.js";
+import "core-js/modules/esnext.reflect.metadata.js";
+import "core-js/modules/esnext.regexp.escape.js";
+import "core-js/modules/esnext.set.add-all.js";
+import "core-js/modules/esnext.set.delete-all.js";
+import "core-js/modules/esnext.set.difference.js";
+import "core-js/modules/esnext.set.every.js";
+import "core-js/modules/esnext.set.filter.js";
+import "core-js/modules/esnext.set.find.js";
+import "core-js/modules/esnext.set.from.js";
+import "core-js/modules/esnext.set.intersection.js";
+import "core-js/modules/esnext.set.is-disjoint-from.js";
+import "core-js/modules/esnext.set.is-subset-of.js";
+import "core-js/modules/esnext.set.is-superset-of.js";
+import "core-js/modules/esnext.set.join.js";
+import "core-js/modules/esnext.set.map.js";
+import "core-js/modules/esnext.set.of.js";
+import "core-js/modules/esnext.set.reduce.js";
+import "core-js/modules/esnext.set.some.js";
+import "core-js/modules/esnext.set.symmetric-difference.js";
+import "core-js/modules/esnext.set.union.js";
+import "core-js/modules/esnext.string.at.js";
+import "core-js/modules/esnext.string.cooked.js";
+import "core-js/modules/esnext.string.code-points.js";
+import "core-js/modules/esnext.string.dedent.js";
+import "core-js/modules/esnext.symbol.async-dispose.js";
+import "core-js/modules/esnext.symbol.custom-matcher.js";
+import "core-js/modules/esnext.symbol.dispose.js";
+import "core-js/modules/esnext.symbol.is-registered-symbol.js";
+import "core-js/modules/esnext.symbol.is-registered.js";
+import "core-js/modules/esnext.symbol.is-well-known-symbol.js";
+import "core-js/modules/esnext.symbol.is-well-known.js";
+import "core-js/modules/esnext.symbol.matcher.js";
+import "core-js/modules/esnext.symbol.metadata.js";
+import "core-js/modules/esnext.symbol.metadata-key.js";
+import "core-js/modules/esnext.symbol.observable.js";
+import "core-js/modules/esnext.symbol.pattern-match.js";
+import "core-js/modules/esnext.symbol.replace-all.js";
+import "core-js/modules/esnext.typed-array.from-async.js";
+import "core-js/modules/esnext.typed-array.filter-out.js";
+import "core-js/modules/esnext.typed-array.filter-reject.js";
+import "core-js/modules/esnext.typed-array.group-by.js";
+import "core-js/modules/esnext.typed-array.to-spliced.js";
+import "core-js/modules/esnext.typed-array.unique-by.js";
+import "core-js/modules/esnext.uint8-array.from-base64.js";
+import "core-js/modules/esnext.uint8-array.from-hex.js";
+import "core-js/modules/esnext.uint8-array.set-from-base64.js";
+import "core-js/modules/esnext.uint8-array.set-from-hex.js";
+import "core-js/modules/esnext.uint8-array.to-base64.js";
+import "core-js/modules/esnext.uint8-array.to-hex.js";
+import "core-js/modules/esnext.weak-map.delete-all.js";
+import "core-js/modules/esnext.weak-map.from.js";
+import "core-js/modules/esnext.weak-map.of.js";
+import "core-js/modules/esnext.weak-map.emplace.js";
+import "core-js/modules/esnext.weak-map.get-or-insert.js";
+import "core-js/modules/esnext.weak-map.get-or-insert-computed.js";
+import "core-js/modules/esnext.weak-map.upsert.js";
+import "core-js/modules/esnext.weak-set.add-all.js";
+import "core-js/modules/esnext.weak-set.delete-all.js";
+import "core-js/modules/esnext.weak-set.from.js";
+import "core-js/modules/esnext.weak-set.of.js";
+import "core-js/modules/web.dom-collections.iterator.js";
+import "core-js/modules/web.dom-exception.constructor.js";
+import "core-js/modules/web.dom-exception.stack.js";
+import "core-js/modules/web.dom-exception.to-string-tag.js";
+import "core-js/modules/web.immediate.js";
+import "core-js/modules/web.queue-microtask.js";
+import "core-js/modules/web.self.js";
+import "core-js/modules/web.structured-clone.js";
+import "core-js/modules/web.url.js";
+import "core-js/modules/web.url.can-parse.js";
+import "core-js/modules/web.url.parse.js";
+import "core-js/modules/web.url.to-json.js";
+import "core-js/modules/web.url-search-params.js";
+import "core-js/modules/web.url-search-params.delete.js";
+import "core-js/modules/web.url-search-params.has.js";
+import "core-js/modules/web.url-search-params.size.js";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
   }
 }"
 `;
@@ -33,6 +374,45 @@ exports[`buildPreset - Babel Transform should transform JSX in production 1`] = 
 const element = /*#__PURE__*/_jsx("div", {
   children: "Hello World"
 });"
+`;
+
+exports[`buildPreset - Babel Transform should transform Object.hasOwn() with caller.library 1`] = `
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
+import _Object$hasOwn from "core-js-pure/stable/object/has-own.js";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}
+console.log(_Object$hasOwn({
+  a: 1
+}, 'a') ? 'yes' : 'no');"
+`;
+
+exports[`buildPreset - Babel Transform should transform Object.hasOwn() with name==@babel/runtime 1`] = `
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
+import _Object$hasOwn from "core-js-pure/stable/object/has-own.js";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}
+console.log(_Object$hasOwn({
+  a: 1
+}, 'a') ? 'yes' : 'no');"
+`;
+
+exports[`buildPreset - Babel Transform should transform Object.hasOwn() with usage-pure 1`] = `
+"import _defineProperty from "@babel/runtime-corejs3/helpers/defineProperty";
+import _Object$hasOwn from "core-js-pure/stable/object/has-own.js";
+class MyClass {
+  constructor() {
+    _defineProperty(this, "myProp", 42);
+  }
+}
+console.log(_Object$hasOwn({
+  a: 1
+}, 'a') ? 'yes' : 'no');"
 `;
 
 exports[`buildPreset - Babel Transform should transform TypeScript to JavaScript 1`] = `"const x = 42;"`;

--- a/packages/babel-preset-anansi/package.json
+++ b/packages/babel-preset-anansi/package.json
@@ -36,7 +36,9 @@
   },
   "devDependencies": {
     "@anansi/browserslist-config": "workspace:*",
-    "@types/node": "^22.0.0"
+    "@babel/runtime": "^7.26.7",
+    "@babel/runtime-corejs3": "^7.26.7",
+    "@types/node": "^22.10.10"
   },
   "dependencies": {
     "@anansi/ts-utils": "workspace:^",
@@ -53,11 +55,12 @@
     "@babel/preset-react": "^7.26.3",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-module-resolver": "^5.0.2",
-    "babel-plugin-react-compiler": "^0.0.0",
+    "babel-plugin-polyfill-corejs3": "^0.11.1",
+    "babel-plugin-react-compiler": "19.0.0-beta-decd7b8-20250118",
     "babel-plugin-root-import": "^6.6.0",
     "babel-plugin-transform-import-meta": "^2.3.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "core-js-compat": "^3.23.5",
+    "core-js-compat": "^3.40.0",
     "glob-to-regexp": "^0.4.1",
     "path": "^0.12.7"
   },
@@ -68,6 +71,7 @@
     "@babel/runtime-corejs3": "^7.10.0",
     "babel-minify": "^0.5.1",
     "core-js": "*",
+    "core-js-pure": "*",
     "lodash": "*",
     "ramda": "*",
     "react-refresh": "*",
@@ -87,6 +91,9 @@
       "optional": true
     },
     "core-js": {
+      "optional": true
+    },
+    "core-js-pure": {
       "optional": true
     },
     "lodash": {

--- a/packages/babel-preset-anansi/presetOutput.test.js
+++ b/packages/babel-preset-anansi/presetOutput.test.js
@@ -47,17 +47,6 @@ describe('buildPreset', () => {
     expect(preset.plugins).toBeDefined();
   });
 
-  it('should handle core-js version correctly', () => {
-    api.env.mockReturnValue('development');
-    const preset = buildPreset(api, {
-      corejs: { version: 3, proposals: true },
-    });
-    expect(preset.presets[0][1].corejs).toEqual({
-      version: 3,
-      proposals: true,
-    });
-  });
-
   it('should handle TypeScript configuration', () => {
     api.env.mockReturnValue('development');
     const preset = buildPreset(api, {

--- a/packages/babel-preset-anansi/transform2018.test.js
+++ b/packages/babel-preset-anansi/transform2018.test.js
@@ -1,4 +1,5 @@
 const babel = require('@babel/core');
+const { library } = require('webpack');
 
 const buildPreset = require('./index');
 
@@ -90,6 +91,76 @@ describe('buildPreset - Babel Transform', () => {
     const transformedCode = transformCode(code, {
       hasJsxRuntime: true,
       loose: true,
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should transform Object.hasOwn() with usage-pure', () => {
+    api.env.mockReturnValue('development');
+    const code = `class MyClass { declare myThing; myProp: number = 42; }console.log(Object.hasOwn({ a: 1 }, 'a') ? 'yes' : 'no');`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+      polyfillMethod: 'usage-pure',
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should transform Object.hasOwn() with name==@babel/runtime', () => {
+    api.env.mockReturnValue('development');
+    api.caller.mockImplementation(cb => cb({ name: '@babel/cli' }));
+    const code = `class MyClass { declare myThing; myProp: number = 42; }console.log(Object.hasOwn({ a: 1 }, 'a') ? 'yes' : 'no');`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should transform Object.hasOwn() with caller.library', () => {
+    api.env.mockReturnValue('development');
+    api.caller.mockImplementation(cb => cb({ library: true }));
+    const code = `class MyClass { declare myThing; myProp: number = 42; }console.log(Object.hasOwn({ a: 1 }, 'a') ? 'yes' : 'no');`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should import Object.hasOwn() polyfill with usage-global', () => {
+    api.env.mockReturnValue('development');
+    const code = `class MyClass { declare myThing; myProp: number = 42; }console.log(Object.hasOwn({ a: 1 }, 'a') ? 'yes' : 'no');`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+      polyfillMethod: 'usage-global',
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should select polyfill entries with entry-global', () => {
+    api.env.mockReturnValue('development');
+    const code = `import 'core-js';class MyClass { declare myThing; myProp: number = 42; }`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+      polyfillMethod: 'entry-global',
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should not transform entry polyfill import when polyfillMethod: `false`', () => {
+    api.env.mockReturnValue('development');
+    const code = `import 'core-js';class MyClass { declare myThing; myProp: number = 42; }`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+      polyfillMethod: false,
+    });
+    expect(transformedCode).toMatchSnapshot();
+  });
+
+  it('should not polyfill when polyfillMethod: `false`', () => {
+    api.env.mockReturnValue('development');
+    const code = `class MyClass { declare myThing; myProp: number = 42; }console.log(Object.hasOwn({ a: 1 }, 'a') ? 'yes' : 'no');`;
+    const transformedCode = transformCode(code, {
+      hasJsxRuntime: true,
+      polyfillMethod: false,
     });
     expect(transformedCode).toMatchSnapshot();
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,9 +82,10 @@
   },
   "dependencies": {
     "@anansi/router": "workspace:^",
-    "@babel/runtime": "^7.17.0",
+    "@babel/runtime-corejs3": "^7.26.7",
     "chalk": "^4.1.2",
     "compression": "^1.7.5",
+    "core-js-pure": "^3.40.0",
     "cross-fetch": "^4.1.0",
     "enhanced-resolve": "^5.18.0",
     "express": "^4.21.2",

--- a/packages/generator-js/package.json
+++ b/packages/generator-js/package.json
@@ -64,11 +64,11 @@
     "npm": ">= 6.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
+    "@babel/runtime-corejs3": "^7.26.0",
     "@types/inquirer": "^9.0.7",
     "@yeoman/types": "^1.5.0",
     "chalk": "^4.1.2",
-    "core-js": "^3.21.0",
+    "core-js-pure": "^3.40.0",
     "ejs": "^3.1.10",
     "execa": "^9.5.2",
     "gulp-filter": "^9.0.1",

--- a/packages/jest-preset-anansi/package.json
+++ b/packages/jest-preset-anansi/package.json
@@ -57,10 +57,10 @@
   },
   "dependencies": {
     "@anansi/ts-utils": "workspace:^",
-    "@babel/runtime": "^7.26.0",
+    "@babel/runtime-corejs3": "^7.26.0",
     "@types/babel__core": "^7.20.5",
     "babel-jest": "^29.7.0",
-    "core-js": "^3.21.0",
+    "core-js-pure": "^3.40.0",
     "cross-fetch": "^4.1.0",
     "jest-pnp-resolver": "^1.2.3",
     "mitt": "^3.0.1",

--- a/packages/pojo-router/package.json
+++ b/packages/pojo-router/package.json
@@ -52,7 +52,8 @@
     "react": "19.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
+    "@babel/runtime-corejs3": "^7.26.0",
+    "core-js-pure": "^3.40.0",
     "history": "5.3.0",
     "path-to-regexp": "^6.3.0"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -44,8 +44,9 @@
     "react": "19.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
+    "@babel/runtime-corejs3": "^7.26.0",
     "@pojo-router/core": "workspace:^",
+    "core-js-pure": "^3.40.0",
     "history": "^5.3.0",
     "nano-memoize": "^3.0.16"
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -36,12 +36,13 @@
     "react"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
+    "@babel/runtime-corejs3": "^7.26.0",
     "@storybook/builder-webpack5": "^8.5.1",
     "@storybook/preset-react-webpack": "^8.5.1",
     "@storybook/react": "^8.5.1",
     "@storybook/types": "^8.5.1",
-    "@types/node": "^22.10.10"
+    "@types/node": "^22.10.10",
+    "core-js-pure": "^3.40.0"
   },
   "peerDependencies": {
     "@anansi/babel-preset": "*",

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -59,7 +59,7 @@
     "sass-embedded": "^1.77.8"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.2",
+    "@babel/runtime-corejs3": "^7.26.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@svgr/webpack": "^8.1.0",
     "@types/sass-loader": "^8.0.9",
@@ -75,7 +75,7 @@
     "clean-webpack-plugin": "^4.0.0",
     "console-browserify": "^1.2.0",
     "constants-browserify": "^1.0.0",
-    "core-js": "^3.21.0",
+    "core-js-pure": "^3.40.0",
     "crypto-browserify": "^3.12.1",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",

--- a/packages/webpack-config-anansi/src/base/generateBabelLoader.js
+++ b/packages/webpack-config-anansi/src/base/generateBabelLoader.js
@@ -13,6 +13,7 @@ export function generateBabelLoader({
   mode,
   babelLoaderOptions,
   noHotReload,
+  library,
 }) {
   const react = require(
     require.resolve('react', {
@@ -71,6 +72,9 @@ export function generateBabelLoader({
     if (noHotReload) {
       babelLoader.options.caller.noHotReload = true;
     }
+  }
+  if (library) {
+    babelLoader.options.caller.library = true;
   }
   return babelLoader;
 }

--- a/packages/webpack-config-anansi/src/base/index.js
+++ b/packages/webpack-config-anansi/src/base/index.js
@@ -31,6 +31,7 @@ export default function makeBaseConfig({
   argv,
   env,
   cssExtractOptions,
+  library,
 }) {
   const WEBPACK_PUBLIC_HOST = process.env.WEBPACK_PUBLIC_HOST || '';
   const WEBPACK_PUBLIC_PATH = process.env.WEBPACK_PUBLIC_PATH || '/';
@@ -60,6 +61,7 @@ export default function makeBaseConfig({
     target: argv?.target,
     mode,
     babelLoaderOptions,
+    library,
   });
   const inJSBabelOptions = {
     ...mainBabelLoader.options,

--- a/packages/webpack-config-anansi/src/prod.js
+++ b/packages/webpack-config-anansi/src/prod.js
@@ -93,7 +93,7 @@ export default function makeProdConfig(
           chunks: 'all',
         },
         polyfill: {
-          test: /[\\/]node_modules[\\/](core-js|@babel\/runtime|regenerator-runtime|ric-shim|babel-runtime)[\\/].*/,
+          test: /[\\/]node_modules[\\/](core-js|core-js-pure|@babel\/runtime|@babel\/runtime-corejs3|regenerator-runtime|ric-shim|babel-runtime)[\\/].*/,
           name: 'polyfill',
           chunks: 'all',
         },

--- a/renovate.json
+++ b/renovate.json
@@ -27,8 +27,10 @@
     {
       "matchPackageNames": [
         "@babel/runtime",
+        "@babel/runtime-corejs2",
         "@babel/runtime-corejs3",
         "core-js",
+        "core-js-pure",
         "core-js-compat"
       ],
       "matchDepTypes": ["dependencies"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,14 +39,17 @@ __metadata:
     "@babel/plugin-transform-typescript": "npm:^7.26.7"
     "@babel/preset-env": "npm:^7.26.7"
     "@babel/preset-react": "npm:^7.26.3"
-    "@types/node": "npm:^22.0.0"
+    "@babel/runtime": "npm:^7.26.7"
+    "@babel/runtime-corejs3": "npm:^7.26.7"
+    "@types/node": "npm:^22.10.10"
     babel-plugin-macros: "npm:^3.1.0"
     babel-plugin-module-resolver: "npm:^5.0.2"
-    babel-plugin-react-compiler: "npm:^0.0.0"
+    babel-plugin-polyfill-corejs3: "npm:^0.11.1"
+    babel-plugin-react-compiler: "npm:19.0.0-beta-decd7b8-20250118"
     babel-plugin-root-import: "npm:^6.6.0"
     babel-plugin-transform-import-meta: "npm:^2.3.2"
     babel-plugin-transform-react-remove-prop-types: "npm:^0.4.24"
-    core-js-compat: "npm:^3.23.5"
+    core-js-compat: "npm:^3.40.0"
     glob-to-regexp: "npm:^0.4.1"
     path: "npm:^0.12.7"
   peerDependencies:
@@ -56,6 +59,7 @@ __metadata:
     "@babel/runtime-corejs3": ^7.10.0
     babel-minify: ^0.5.1
     core-js: "*"
+    core-js-pure: "*"
     lodash: "*"
     ramda: "*"
     react-refresh: "*"
@@ -70,6 +74,8 @@ __metadata:
     babel-minify:
       optional: true
     core-js:
+      optional: true
+    core-js-pure:
       optional: true
     lodash:
       optional: true
@@ -775,6 +781,21 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
   checksum: 10c0/f777fe0ee1e467fdaaac059c39ed203bdc94ef2465fb873316e9e1acfc511a276263724b061e3b0af2f6d7ad3ff174f2bb368fde236a860e0f650fda43d7e022
+  languageName: node
+  linkType: hard
+
+"@babel/helper-define-polyfill-provider@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.6.3"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.22.6"
+    "@babel/helper-plugin-utils": "npm:^7.22.5"
+    debug: "npm:^4.1.1"
+    lodash.debounce: "npm:^4.0.8"
+    resolve: "npm:^1.14.2"
+  peerDependencies:
+    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+  checksum: 10c0/4320e3527645e98b6a0d5626fef815680e3b2b03ec36045de5e909b0f01546ab3674e96f50bf3bc8413f8c9037e5ee1a5f560ebdf8210426dad1c2c03c96184a
   languageName: node
   linkType: hard
 
@@ -2067,7 +2088,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.26.7, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime-corejs3@npm:^7.26.7":
+  version: 7.26.7
+  resolution: "@babel/runtime-corejs3@npm:7.26.7"
+  dependencies:
+    core-js-pure: "npm:^3.30.2"
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/399855ab2a1ef21364683a1a40a3280be71dbfee587c90fb57fce4508a783a846f925b7d5509bba3521674f44f76b4f8d31eb8a32e13dc333cdacd34c31f5119
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:7.26.7, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
   version: 7.26.7
   resolution: "@babel/runtime@npm:7.26.7"
   dependencies:
@@ -2102,7 +2133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.23.5, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.5, @babel/types@npm:^7.26.7, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.23.5, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.5, @babel/types@npm:^7.26.7, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.26.7
   resolution: "@babel/types@npm:7.26.7"
   dependencies:
@@ -7959,6 +7990,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-polyfill-corejs3@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.11.1"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": "npm:^0.6.3"
+    core-js-compat: "npm:^3.40.0"
+  peerDependencies:
+    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+  checksum: 10c0/025f754b6296d84b20200aff63a3c1acdd85e8c621781f2bd27fe2512d0060526192d02329326947c6b29c27cf475fbcfaaff8c51eab1d2bfc7b79086bb64229
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-regenerator@npm:^0.6.1":
   version: 0.6.1
   resolution: "babel-plugin-polyfill-regenerator@npm:0.6.1"
@@ -7970,10 +8013,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-react-compiler@npm:^0.0.0":
-  version: 0.0.0
-  resolution: "babel-plugin-react-compiler@npm:0.0.0"
-  checksum: 10c0/b7db0bd49dfe28ea8945a72e90a21f1ab8a14e5ed6987a4f8780bbf15e68bb742aa0be45c019084390623a73c39c44dd57964cc71a01093f4f929c09eb5e5e50
+"babel-plugin-react-compiler@npm:19.0.0-beta-decd7b8-20250118":
+  version: 19.0.0-beta-decd7b8-20250118
+  resolution: "babel-plugin-react-compiler@npm:19.0.0-beta-decd7b8-20250118"
+  dependencies:
+    "@babel/types": "npm:^7.19.0"
+  checksum: 10c0/a7e33e56b51c593d8e03eb2f19a15b9cbdc4c5934fcdfc0bf6a2bfb5b8187a391bdb2e9ba6a330a398040b041eb9cba444720a329caf8fc3870d05a3b6a15bf5
   languageName: node
   linkType: hard
 
@@ -8423,6 +8468,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.24.3":
+  version: 4.24.4
+  resolution: "browserslist@npm:4.24.4"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001688"
+    electron-to-chromium: "npm:^1.5.73"
+    node-releases: "npm:^2.0.19"
+    update-browserslist-db: "npm:^1.1.1"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/db7ebc1733cf471e0b490b4f47e3e2ea2947ce417192c9246644e92c667dd56a71406cc58f62ca7587caf828364892e9952904a02b7aead752bc65b62a37cfe9
+  languageName: node
+  linkType: hard
+
 "bs-logger@npm:^0.2.6":
   version: 0.2.6
   resolution: "bs-logger@npm:0.2.6"
@@ -8739,6 +8798,13 @@ __metadata:
   version: 1.0.30001666
   resolution: "caniuse-lite@npm:1.0.30001666"
   checksum: 10c0/2d49e9be676233c24717f12aad3d01b3e5f902b457fe1deefaa8d82e64786788a8f79381ae437c61b50e15c9aea8aeb59871b1d54cb4c28b9190d53d292e2339
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001688":
+  version: 1.0.30001695
+  resolution: "caniuse-lite@npm:1.0.30001695"
+  checksum: 10c0/acf90a767051fdd8083711b3ff9f07a28149c55e394115d8f874f149aa4f130e6bc50cea1dd94fe03035b9ebbe13b64f446518a6d2e19f72650962bdff44b2c5
   languageName: node
   linkType: hard
 
@@ -9689,7 +9755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.23.5, core-js-compat@npm:^3.38.0, core-js-compat@npm:^3.38.1":
+"core-js-compat@npm:^3.38.0, core-js-compat@npm:^3.38.1":
   version: 3.38.1
   resolution: "core-js-compat@npm:3.38.1"
   dependencies:
@@ -9698,10 +9764,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js-compat@npm:^3.40.0":
+  version: 3.40.0
+  resolution: "core-js-compat@npm:3.40.0"
+  dependencies:
+    browserslist: "npm:^4.24.3"
+  checksum: 10c0/44f6e88726fe266a5be9581a79766800478a8d5c492885f2d4c2a4e2babd9b06bc1689d5340d3a61ae7332f990aff2e83b6203ff8773137a627cfedfbeefabeb
+  languageName: node
+  linkType: hard
+
 "core-js-pure@npm:^3.23.3":
   version: 3.29.1
   resolution: "core-js-pure@npm:3.29.1"
   checksum: 10c0/d1f5324eb01da1f196c307e7c1f06f65c9516f97a5b3e0b566098d2c205e517bf5fb9dbddf0babfa2ab1057f96156509ed4929aef16b823af8debe0fde71fcc0
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.30.2":
+  version: 3.40.0
+  resolution: "core-js-pure@npm:3.40.0"
+  checksum: 10c0/97590017216e2614e44bacc0b73159061b58e3ac86b61a3ed8cd78fc12bef604c5fb559a7a4d51ae5f2d1bd23ec57760ba6bf2802e802beb42d6bbce136acf52
   languageName: node
   linkType: hard
 
@@ -10925,6 +11007,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.5.73":
+  version: 1.5.88
+  resolution: "electron-to-chromium@npm:1.5.88"
+  checksum: 10c0/25946ef310f8e14c763fcf0e62094e7eae2273d9ffe908969ddd97492c3df0198739295ba76388dc210c4503ab6b540130779cd83036f80520cb8efee53be8e4
+  languageName: node
+  linkType: hard
+
 "elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
   version: 6.6.0
   resolution: "elliptic@npm:6.6.0"
@@ -11353,6 +11442,13 @@ __metadata:
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
   checksum: 10c0/6b4adafecd0682f3aa1cd1106b8fff30e492c7015b178bc81b2d2f75106dabea6c6d6e8508fc491bd58e597c74abb0e8e2368f943ecb9393d4162e3c2f3cf287
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
   languageName: node
   linkType: hard
 
@@ -17968,6 +18064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.19":
+  version: 2.0.19
+  resolution: "node-releases@npm:2.0.19"
+  checksum: 10c0/52a0dbd25ccf545892670d1551690fe0facb6a471e15f2cfa1b20142a5b255b3aa254af5f59d6ecb69c2bec7390bc643c43aa63b13bf5e64b6075952e716b1aa
+  languageName: node
+  linkType: hard
+
 "noms@npm:0.0.0":
   version: 0.0.0
   resolution: "noms@npm:0.0.0"
@@ -22111,6 +22214,7 @@ __metadata:
     "@anansi/eslint-plugin": "workspace:*"
     "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:7.26.7"
+    "@babel/runtime-corejs3": "npm:^7.26.7"
     "@commitlint/cli": "npm:19.6.1"
     "@commitlint/config-conventional": "npm:19.6.0"
     "@lerna-lite/cli": "npm:3.11.0"
@@ -24994,6 +25098,20 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: 10c0/a7452de47785842736fb71547651c5bbe5b4dc1e3722ccf48a704b7b34e4dcf633991eaa8e4a6a517ffb738b3252eede3773bef673ef9021baa26b056d63a5b9
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "update-browserslist-db@npm:1.1.2"
+  dependencies:
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.1"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 10c0/9cb353998d6d7d6ba1e46b8fa3db888822dd972212da4eda609d185eb5c3557a93fd59780ceb757afd4d84240518df08542736969e6a5d6d6ce2d58e9363aac6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,7 @@ __metadata:
   dependencies:
     "@anansi/router": "workspace:^"
     "@ant-design/cssinjs": "npm:^1.7.1"
-    "@babel/runtime": "npm:^7.17.0"
+    "@babel/runtime-corejs3": "npm:^7.26.7"
     "@data-client/react": "npm:^0.14.0"
     "@types/compression": "npm:1.7.5"
     "@types/express": "npm:^4.17.17"
@@ -139,6 +139,7 @@ __metadata:
     "@types/webpack-node-externals": "npm:^3"
     chalk: "npm:^4.1.2"
     compression: "npm:^1.7.5"
+    core-js-pure: "npm:^3.40.0"
     cross-fetch: "npm:^4.1.0"
     enhanced-resolve: "npm:^5.18.0"
     express: "npm:^4.21.2"
@@ -225,7 +226,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@anansi/generator-js@workspace:packages/generator-js"
   dependencies:
-    "@babel/runtime": "npm:^7.17.0"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@types/ejs": "npm:3.1.5"
     "@types/gulp-filter": "npm:3.0.39"
     "@types/inquirer": "npm:^9.0.7"
@@ -234,7 +235,7 @@ __metadata:
     "@yeoman/types": "npm:^1.5.0"
     chalk: "npm:^4.1.2"
     copyfiles: "npm:2.4.1"
-    core-js: "npm:^3.21.0"
+    core-js-pure: "npm:^3.40.0"
     ejs: "npm:^3.1.10"
     execa: "npm:^9.5.2"
     gulp-filter: "npm:^9.0.1"
@@ -255,12 +256,12 @@ __metadata:
   resolution: "@anansi/jest-preset@workspace:packages/jest-preset-anansi"
   dependencies:
     "@anansi/ts-utils": "workspace:^"
-    "@babel/runtime": "npm:^7.26.0"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@types/babel__core": "npm:^7.20.5"
     "@types/node": "npm:^22.0.0"
     babel-jest: "npm:^29.7.0"
     copyfiles: "npm:2.4.1"
-    core-js: "npm:^3.21.0"
+    core-js-pure: "npm:^3.40.0"
     cross-fetch: "npm:^4.1.0"
     jest-pnp-resolver: "npm:^1.2.3"
     mitt: "npm:^3.0.1"
@@ -286,10 +287,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@anansi/router@workspace:packages/router"
   dependencies:
-    "@babel/runtime": "npm:^7.17.0"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@pojo-router/core": "workspace:^"
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:types-react@19.0.0-rc.1"
+    core-js-pure: "npm:^3.40.0"
     history: "npm:^5.3.0"
     nano-memoize: "npm:^3.0.16"
     react: "npm:19.0.0"
@@ -306,12 +308,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@anansi/storybook@workspace:packages/storybook"
   dependencies:
-    "@babel/runtime": "npm:^7.17.0"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@storybook/builder-webpack5": "npm:^8.5.1"
     "@storybook/preset-react-webpack": "npm:^8.5.1"
     "@storybook/react": "npm:^8.5.1"
     "@storybook/types": "npm:^8.5.1"
     "@types/node": "npm:^22.10.10"
+    core-js-pure: "npm:^3.40.0"
   peerDependencies:
     "@anansi/babel-preset": "*"
     "@anansi/webpack-config": ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0
@@ -2088,7 +2091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.26.0, @babel/runtime-corejs3@npm:^7.26.7":
+"@babel/runtime-corejs3@npm:7.26.7, @babel/runtime-corejs3@npm:^7.26.0, @babel/runtime-corejs3@npm:^7.26.7":
   version: 7.26.7
   resolution: "@babel/runtime-corejs3@npm:7.26.7"
   dependencies:
@@ -2098,7 +2101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.26.7, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
   version: 7.26.7
   resolution: "@babel/runtime@npm:7.26.7"
   dependencies:
@@ -4721,9 +4724,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@pojo-router/core@workspace:packages/pojo-router"
   dependencies:
-    "@babel/runtime": "npm:^7.17.0"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@types/node": "npm:^22.0.0"
     "@types/react": "npm:types-react@19.0.0-rc.1"
+    core-js-pure: "npm:^3.40.0"
     history: "npm:5.3.0"
     path-to-regexp: "npm:^6.3.0"
     react: "npm:19.0.0"
@@ -9787,7 +9791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.40.0, core-js@npm:^3.21.0, core-js@npm:^3.6.5":
+"core-js@npm:3.40.0, core-js@npm:^3.6.5":
   version: 3.40.0
   resolution: "core-js@npm:3.40.0"
   checksum: 10c0/db7946ada881e845d8b157061945b1187618fa45cf162f392a151e8a497962aed2da688c982eaa1d444c864be97a70f8be4d73385294b515d224dd164d19f1d4
@@ -11931,7 +11935,7 @@ __metadata:
     "@anansi/webpack-config": "npm:^20.0.16"
     "@babel/core": "npm:^7.21.3"
     "@babel/plugin-transform-modules-commonjs": "npm:7.26.3"
-    "@babel/runtime": "npm:7.26.7"
+    "@babel/runtime-corejs3": "npm:7.26.7"
     "@linaria/core": "npm:6.2.0"
     "@linaria/react": "npm:6.2.1"
     "@types/babel__core": "npm:^7.20.0"
@@ -11973,7 +11977,7 @@ __metadata:
     "@ant-design/cssinjs": "npm:1.23.0"
     "@ant-design/icons": "npm:^5.0.1"
     "@babel/core": "npm:7.26.7"
-    "@babel/runtime": "npm:7.26.7"
+    "@babel/runtime-corejs3": "npm:7.26.7"
     "@data-client/endpoint": "npm:0.14.17"
     "@data-client/hooks": "npm:0.2.0"
     "@data-client/img": "npm:0.14.15"
@@ -12019,7 +12023,7 @@ __metadata:
     "@ant-design/icons": "npm:^5.0.1"
     "@ant-design/pro-layout": "npm:7.12.3"
     "@babel/core": "npm:^7.21.3"
-    "@babel/runtime": "npm:7.26.7"
+    "@babel/runtime-corejs3": "npm:7.26.7"
     "@data-client/graphql": "npm:0.14.17"
     "@data-client/react": "npm:0.14.18"
     "@data-client/rest": "npm:0.14.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@anansi/webpack-config@workspace:packages/webpack-config-anansi"
   dependencies:
-    "@babel/runtime": "npm:^7.17.2"
+    "@babel/runtime-corejs3": "npm:^7.26.0"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.15"
     "@svgr/webpack": "npm:^8.1.0"
     "@types/node": "npm:^22.0.0"
@@ -360,7 +360,7 @@ __metadata:
     clean-webpack-plugin: "npm:^4.0.0"
     console-browserify: "npm:^1.2.0"
     constants-browserify: "npm:^1.0.0"
-    core-js: "npm:^3.21.0"
+    core-js-pure: "npm:^3.40.0"
     crypto-browserify: "npm:^3.12.1"
     css-loader: "npm:^7.1.2"
     css-minimizer-webpack-plugin: "npm:^7.0.0"
@@ -2088,7 +2088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.26.7":
+"@babel/runtime-corejs3@npm:^7.26.0, @babel/runtime-corejs3@npm:^7.26.7":
   version: 7.26.7
   resolution: "@babel/runtime-corejs3@npm:7.26.7"
   dependencies:
@@ -2098,7 +2098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.26.7, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:7.26.7, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.2.0, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.6, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.26.7, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
   version: 7.26.7
   resolution: "@babel/runtime@npm:7.26.7"
   dependencies:
@@ -9780,7 +9780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.30.2":
+"core-js-pure@npm:^3.30.2, core-js-pure@npm:^3.40.0":
   version: 3.40.0
   resolution: "core-js-pure@npm:3.40.0"
   checksum: 10c0/97590017216e2614e44bacc0b73159061b58e3ac86b61a3ed8cd78fc12bef604c5fb559a7a4d51ae5f2d1bd23ec57760ba6bf2802e802beb42d6bbce136acf52


### PR DESCRIPTION
### Polyfills

#### polyfillMethod

‘usage-global’ | ‘entry-global’ | ‘usage-pure’ | false | undefined

This determines how to handle polyfills.

[plugin reference](https://github.com/babel/babel-polyfills/blob/main/docs/migration.md)

##### undefined

This is the default - it will automatically determine a reasonable default based on other factors.

'usage-pure' when detecting 'library build' (@babel/cli or caller.library is true)

Otherwise, if 'core-js' and '@babel/runtime' package are found, 'usage-global'.

If just 'core-js' is found, 'usage-entry'

Otherwise `false`.

##### usage-entry

Transforms core-js import into only the polyfills needed for the target environment. This can be best when
a good code-splitting strategy for polyfills is in the place.

Turns

```js
import 'core-js'
```

into

```js
import 'core-js/es/object/has-own'
// whatever else is needed for target env
```

Like [useBuiltins: entry](https://babeljs.io/docs/babel-preset-env#usebuiltins-entry) for babel-preset-env.

##### usage-global

Only imports polyfills as-needed both based on target environment and usage.

```js
import 'core-js/es/object/has-own'
Object.hasOwn({ a: 1 }, 'a')
```

Like [useBuiltins: usage](https://babeljs.io/docs/babel-preset-env#usebuiltins-usage) for babel-preset-env.

##### usage-pure

This doesn't pollute the global scope. This is recommended when bundling libraries.

```js
import _Object$hasOwn from "core-js-pure/stable/object/has-own.js"
_Object$hasOwn({ a: 1 }, 'a')
```

##### false

Do not perform any transforms related to core-js or polyfills.

#### corejsVersion

Specifies the core-js version to target. Without specified will use the version found by importing.