### PR TITLE
internal: add package bugs metadata

### DIFF
--- a/packages/babel-preset-anansi/package.json
+++ b/packages/babel-preset-anansi/package.json
@@ -31,6 +31,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/babel-preset-anansi"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "engines": {
     "node": ">=14"
   },

--- a/packages/browserslist-config-anansi/package.json
+++ b/packages/browserslist-config-anansi/package.json
@@ -15,6 +15,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/browserslist-config-anansi"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "engines": {
     "node": ">=8.9.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/cli"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Nathaniel Tucker",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/core"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Nathaniel Tucker",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,6 +29,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/eslint-plugin"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "engines": {
     "node": "^18.18.0 || >=20.0.0"
   },

--- a/packages/generator-js/package.json
+++ b/packages/generator-js/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/generator"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Nathaniel Tucker",

--- a/packages/jest-preset-anansi/package.json
+++ b/packages/jest-preset-anansi/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/jest-preset-anansi"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Nathaniel Tucker",

--- a/packages/pojo-router/package.json
+++ b/packages/pojo-router/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/pojo-router"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": "William Klancnik",
   "contributors": [

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/router"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Nathaniel Tucker",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -8,6 +8,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/storybook"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "devDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/ts-utils/package.json
+++ b/packages/ts-utils/package.json
@@ -25,6 +25,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/ts-utils"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "engines": {
     "node": ">=10.13.0"
   },

--- a/packages/webpack-config-anansi/package.json
+++ b/packages/webpack-config-anansi/package.json
@@ -51,6 +51,9 @@
     "url": "git+ssh://git@github.com:ntucker/anansi.git",
     "directory": "packages/webpack-config-anansi"
   },
+  "bugs": {
+    "url": "https://github.com/ntucker/anansi/issues"
+  },
   "engines": {
     "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
   },


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata for published Anansi packages that already point to this repository
- keep runtime code, dependencies, package versions, entry points, and published file globs unchanged

## Packages updated
- `@anansi/babel-preset`
- `@anansi/browserslist-config`
- `@anansi/cli`
- `@anansi/core`
- `@anansi/eslint-plugin`
- `@anansi/generator-js`
- `@anansi/jest-preset`
- `@pojo-router/core`
- `@anansi/router`
- `@anansi/storybook`
- `@anansi/ts-utils`
- `@anansi/webpack-config`

## Validation
- metadata assertion for all updated package manifests
- `corepack yarn install --immutable --mode=skip-build`
- `corepack yarn workspace @anansi/jest-preset run build`
- `npm pack --dry-run --json` for each updated package, using a temporary local PATH shim for the repository's `run <script>` helper command
- `git diff --check`

Note: the temporary PATH shim only maps `run <script>` to `corepack yarn run <script>` for local verification; no repository files are changed by it.